### PR TITLE
Add workflow to run Speakeasy on PR spec changes

### DIFF
--- a/.github/workflows/speakeasy_run_on_pr.yaml
+++ b/.github/workflows/speakeasy_run_on_pr.yaml
@@ -1,0 +1,43 @@
+name: Run Speakeasy on PR
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .speakeasy/in.openapi.yaml
+
+jobs:
+  run-speakeasy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Speakeasy
+        uses: speakeasy-api/sdk-generation-action@v15
+        with:
+          speakeasy_version: latest
+
+      - name: Run Speakeasy
+        run: speakeasy run
+
+      - name: Commit changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: run speakeasy and update generated files"
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a new GitHub workflow that automatically runs `speakeasy run` when `.speakeasy/in.openapi.yaml` is modified in a PR
- Commits generated changes back to the PR branch
- Can be triggered manually via `workflow_dispatch`

## Test plan
- [ ] Create a PR that modifies `.speakeasy/in.openapi.yaml` and verify the workflow runs
- [ ] Verify that changes to `.speakeasy/out.openapi.yaml` do NOT trigger the workflow
- [ ] Test manual workflow trigger from GitHub Actions tab