### PR TITLE
Remove npm dist tag override from publish workflow

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -17,7 +17,6 @@ jobs:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
     with:
       target: openrouter
-      publish_npm_dist_tag: latest
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Removes the hardcoded `publish_npm_dist_tag: latest` configuration from the SDK publish workflow
- Allows Speakeasy to use its default dist tag behavior instead of forcing all releases to use the `latest` tag

## Test plan
- [ ] Verify workflow file syntax is correct
- [ ] Confirm Speakeasy's default behavior meets requirements