### PR TITLE
Version bump to 0.0.1-beta.4

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -17,6 +17,7 @@ jobs:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
     with:
       target: openrouter
+      publish_npm_dist_tag: latest
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Updates SDK version from 0.0.1-beta.3 to 0.0.1-beta.4
- Updates `.genignore` to exclude `.npmignore` and `tsconfig.json`
- Regenerated by Speakeasy SDK generation

## Test plan
- [ ] Verify package builds successfully
- [ ] Confirm version numbers are correct across all files