### PR TITLE
Fix quickstart documentation errors

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -13,7 +13,7 @@ const client = new OpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY
 });
 
-const response = await client.chat.completions.create({
+const response = await client.chat.send({
   model: "minimax/minimax-m2",
   messages: [
     { role: "user", content: "Explain quantum computing" }
@@ -29,7 +29,7 @@ The SDK is automatically generated from OpenRouter's OpenAPI specs and updated w
 
 ```typescript
 // When new models launch, they're available instantly
-const response = await client.chat.completions.create({
+const response = await client.chat.send({
   model: "minimax/minimax-m2",
 });
 ```
@@ -39,7 +39,7 @@ const response = await client.chat.completions.create({
 Every parameter, response field, and configuration option is fully typed. Invalid configurations are caught at compile time, not in production.
 
 ```typescript
-const response = await client.chat.completions.create({
+const response = await client.chat.send({
   model: "minimax/minimax-m2",
   messages: [
     { role: "user", content: "Hello" }
@@ -61,7 +61,7 @@ const response = await client.chat.completions.create({
 **Type-safe streaming:**
 
 ```typescript
-const stream = await client.chat.completions.create({
+const stream = await client.chat.send({
   model: "minimax/minimax-m2",
   messages: [{ role: "user", content: "Write a story" }],
   stream: true
@@ -90,7 +90,7 @@ const client = new OpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY
 });
 
-const response = await client.chat.completions.create({
+const response = await client.chat.send({
   model: "minimax/minimax-m2",
   messages: [
     { role: "user", content: "Hello!" }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const result = await openRouter.chat.send({
       content: "Hello, how are you?",
     },
   ],
-  model: "openai/gpt-5"
+  model: "openai/gpt-5",
   provider: {
     zdr: true,
     sort: "price",
@@ -81,8 +81,8 @@ const result = await openRouter.chat.send({
   stream: true
 });
 
-for await (const chunk of stream) {
-  console.log(hunk.choices[0].delta.content)
+for await (const chunk of result) {
+  console.log(chunk.choices[0].delta.content)
 }
 
 ```


### PR DESCRIPTION
## Summary
- Fixed incorrect API method calls from `client.chat.completions.create` to `client.chat.send` throughout documentation
- Fixed syntax and variable errors in README.md streaming example

## Changes
### OVERVIEW.md
- Updated 5 instances of `client.chat.completions.create` to `client.chat.send` to match actual SDK API

### README.md
- Added missing comma after model parameter (syntax error)
- Fixed variable name from `stream` to `result` in streaming example
- Fixed typo from `hunk` to `chunk` in console.log statement

## Test plan
- [x] Verified all code examples use correct API method `client.chat.send`
- [x] Verified streaming example has correct variable names and syntax
- [x] Confirmed actual SDK implementation uses `chat.send()` method
- [x] Checked all other example files are already correct