### PR TITLE
feat: add monorepo sync notification workflow

### DIFF
--- a/.github/workflows/notify-monorepo.yaml
+++ b/.github/workflows/notify-monorepo.yaml
@@ -1,0 +1,46 @@
+name: Notify Monorepo of Changes
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  notify-monorepo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository dispatch to monorepo
+        run: |
+          # Determine which event type to send based on repository name
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"  # Gets 'typescript-sdk' from 'OpenRouterTeam/typescript-sdk'
+
+          case "$REPO_NAME" in
+            "typescript-sdk")
+              EVENT_TYPE="sync-typescript-sdk"
+              ;;
+            "python-sdk")
+              EVENT_TYPE="sync-python-sdk"
+              ;;
+            "ai-sdk-provider")
+              EVENT_TYPE="sync-ai-sdk-provider"
+              ;;
+            "cli")
+              EVENT_TYPE="sync-cli"
+              ;;
+            *)
+              echo "Unknown repository: $REPO_NAME"
+              exit 1
+              ;;
+          esac
+
+          echo "Sending repository_dispatch event: $EVENT_TYPE"
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.MONOREPO_SYNC_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/OpenRouterTeam/openrouter-web/dispatches \
+            -d "{\"event_type\":\"$EVENT_TYPE\",\"client_payload\":{\"repository\":\"$GITHUB_REPOSITORY\",\"ref\":\"$GITHUB_REF\",\"sha\":\"$GITHUB_SHA\"}}"
+
+          echo "✅ Notification sent to monorepo"


### PR DESCRIPTION
## 🔄 Automated Monorepo Sync

This PR adds a workflow that automatically notifies the `openrouter-web` monorepo when changes are pushed to `main` in this repository.

## How It Works

```
typescript-sdk (this repo)          openrouter-web (monorepo)
├─ Commit pushed to main            ├─ Receives repository_dispatch
├─ notify-monorepo.yaml triggers    ├─ Syncs typescript subtree
├─ Sends webhook event ────────────>├─ Creates PR with changes
                                     └─ Auto-merges if CI passes
```

## What's Added

**File:** `.github/workflows/notify-monorepo.yaml`

**Trigger:** Runs automatically on every push to `main`

**Action:** Sends a `repository_dispatch` event to the monorepo to trigger subtree sync

## Setup Required

After merging this PR, an admin needs to add a secret:

1. Go to **Settings → Secrets and variables → Actions**
2. Click **New repository secret**
3. Name: `MONOREPO_SYNC_TOKEN`
4. Value: GitHub Personal Access Token with `repo` scope
5. Click **Add secret**

The token allows this repo to trigger workflows in the monorepo.

## Benefits

- ✅ Automatic sync of changes to monorepo
- ✅ Changes reviewed via PR before merging to monorepo
- ✅ No manual intervention needed
- ✅ Fast propagation of fixes and features

## Testing

After setup is complete:
1. Push a commit to `main` in this repo
2. Check **Actions** tab - "Notify Monorepo of Changes" should run
3. Check `openrouter-web` **Actions** - "Sync Subtrees" should trigger
4. A PR should be created in `openrouter-web` with the changes

---

Related: OpenRouterTeam/openrouter-web#9617