### PR TITLE
chore: bump version to 0.1.18

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.659.0
   generationVersion: 2.755.9
-  releaseVersion: 0.1.17
-  configChecksum: 981848e5179cd35dc81cd362029ee736
+  releaseVersion: 0.1.18
+  configChecksum: ad5a220c1110e01ccea49eed2d7bb48c
   repoURL: https://github.com/OpenRouterTeam/typescript-sdk.git
   installationURL: https://github.com/OpenRouterTeam/typescript-sdk
   published: true

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -30,7 +30,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 typescript:
-  version: 0.1.17
+  version: 0.1.18
   acceptHeaderEnum: false
   additionalDependencies:
     dependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -14,7 +14,7 @@ targets:
         sourceRevisionDigest: sha256:ffe0e925561a55a1b403667fe33bb3158e05892ef1e66f56211544c9a890b301
         sourceBlobDigest: sha256:18aa7b22686c2f559af1062fea408a9f80146231027ed1fd62b68df38c71f65d
         codeSamplesNamespace: open-router-chat-completions-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:4206cfd1ad4a613178d55c5c1b1da20bcfd21bbaf1b63b8c80beec4bf16dd4b7
+        codeSamplesRevisionDigest: sha256:773f28292c3a6cff16578829c01a9ffb37f23d3c27b607e7e7e97f55cfd00f64
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@openrouter/sdk",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openrouter/sdk",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openrouter/sdk",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/sdk",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "author": "OpenRouter",
   "description": "The OpenRouter TypeScript SDK is a type-safe toolkit for building AI applications with access to 300+ language models through a unified API.",
   "keywords": [

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -69,7 +69,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "0.1.17",
+  sdkVersion: "0.1.18",
   genVersion: "2.755.9",
-  userAgent: "speakeasy-sdk/typescript 0.1.17 2.755.9 1.0.0 @openrouter/sdk",
+  userAgent: "speakeasy-sdk/typescript 0.1.18 2.755.9 1.0.0 @openrouter/sdk",
 } as const;


### PR DESCRIPTION
## Summary
- Regenerate SDK with speakeasy run
- Bump version from 0.1.17 to 0.1.18

## Test plan
- [ ] Verify build succeeds
- [ ] Verify tests pass