### PR TITLE
refactor: replace eval with ShadowRealm for safe expression evaluation

### DIFF
--- a/examples/tools-example.ts
+++ b/examples/tools-example.ts
@@ -23,6 +23,14 @@ import * as dotenv from 'dotenv';
 import { z } from 'zod/v4';
 import { OpenRouter, ToolType } from '../src/index.js';
 
+// Type declaration for ShadowRealm (TC39 Stage 3 proposal)
+// See: https://tc39.es/proposal-shadowrealm/
+declare class ShadowRealm {
+  constructor();
+  evaluate(sourceText: string): unknown;
+  importValue(specifier: string, bindingName: string): Promise<unknown>;
+}
+
 dotenv.config();
 
 const client = new OpenRouter({
@@ -168,21 +176,28 @@ async function generatorToolExample() {
  *
  * ShadowRealm provides a secure, isolated JavaScript execution environment
  * that prevents access to the host realm's globals (no access to DOM, fetch,
- * filesystem, etc.). This makes it safe for evaluating untrusted expressions.
+ * filesystem, etc.). Combined with input validation, this makes it safe for
+ * evaluating untrusted math expressions.
+ *
+ * Note: ShadowRealm isolates from host APIs but does not prevent DoS vectors
+ * like infinite loops. For production use, consider additional safeguards.
  *
  * Browser support: Chrome 124+, Edge 124+, Firefox 128+, Safari 18+
  * Node.js support: Available behind --experimental-shadow-realm flag (v19+)
  * See: https://tc39.es/proposal-shadowrealm/
  */
-async function safeEvaluateMath(expression: string): Promise<number> {
-  // ShadowRealm is a TC39 Stage 3 proposal for isolated JavaScript execution
-  // It creates a separate realm with its own global object, preventing access
-  // to the host environment's APIs (no DOM, no Node.js APIs, no fetch, etc.)
+function safeEvaluateMath(expression: string): number {
+  // Only allow digits, whitespace, basic operators, decimal point, and parentheses
+  if (!/^[\d\s+\-*/.()]+$/.test(expression)) {
+    throw new Error('Expression contains invalid characters');
+  }
+
+  // ShadowRealm creates a separate realm with its own global object, preventing
+  // access to the host environment's APIs (no DOM, no Node.js APIs, no fetch, etc.)
   const realm = new ShadowRealm();
 
-  // The expression is evaluated in complete isolation - even if malicious code
-  // is injected, it cannot access anything outside the shadow realm
-  const result = await realm.evaluate(`(${expression})`);
+  // The expression is evaluated in complete isolation
+  const result = realm.evaluate(expression);
 
   if (typeof result !== 'number' || !Number.isFinite(result)) {
     throw new Error('Expression did not evaluate to a finite number');
@@ -233,7 +248,7 @@ async function manualToolExample() {
 
       // Safely evaluate the math expression using ShadowRealm
       try {
-        const _result = await safeEvaluateMath(expression);
+        const _result = safeEvaluateMath(expression);
       } catch (_error) {}
     }
   }


### PR DESCRIPTION
## Summary

Removes the dangerous `eval()` usage from the manual tool execution example (`examples/tools-example.ts`) and replaces it with the ShadowRealm API for secure, isolated JavaScript execution.

ShadowRealm provides a separate realm with its own global object, preventing evaluated code from accessing the host environment's APIs (no DOM, no Node.js APIs, no fetch, etc.). Combined with input validation, this provides defense-in-depth for evaluating math expressions.

## Updates since last revision

Addressed PR feedback:
- Added TypeScript type declaration for ShadowRealm (Stage 3 proposal)
- Made `safeEvaluateMath` synchronous per TC39 spec (`evaluate()` is sync, not async)
- Added input validation regex `/^[\d\s+\-*/.()]+$/` to only allow safe math characters
- Removed unnecessary parentheses wrapping around expression
- Added doc comment noting that ShadowRealm doesn't prevent DoS vectors like infinite loops

## Review & Testing Checklist for Human

- [ ] **Test the example runs** - Requires Node.js with `--experimental-shadow-realm` flag. Verify the example actually executes without errors.
- [ ] **Verify regex validation is correct** - The regex `/^[\d\s+\-*/.()]+$/` should only allow digits, whitespace, operators (+, -, *, /), decimal point, and parentheses. Confirm no edge cases allow malicious input.
- [ ] **Confirm type declaration matches spec** - The manually added `declare class ShadowRealm` should match https://tc39.es/proposal-shadowrealm/

**Recommended test plan:**
```bash
cd examples
node --experimental-shadow-realm -r ts-node/register tools-example.ts
```

### Notes

- ShadowRealm is a TC39 Stage 3 proposal with limited runtime support (Chrome 124+, Node.js 19+ with flag)
- The code includes documentation comments with browser/Node.js support info and a link to the spec for developer education
- While ShadowRealm isolates from host APIs, it doesn't prevent DoS vectors like infinite loops (documented in code comments)

**Requested by:** Tom Aylott (@subtleGradient)
**Link to Devin run:** https://app.devin.ai/sessions/51990981c3dc4d3b99fb9f0e2e7a3702