### PR TITLE
Remove unused streaming response type from embeddings endpoint

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -6716,11 +6716,6 @@ paths:
                   - object
                   - data
                   - model
-            text/event-stream:
-              schema:
-                type: string
-                description: Not used for embeddings - embeddings do not support streaming
-              x-speakeasy-sse-sentinel: '[DONE]'
         '400':
           description: Bad Request - Invalid request parameters or malformed input
           content:


### PR DESCRIPTION
## Summary

Fixes #98

The embeddings endpoint has a `text/event-stream` response type in the OpenAPI spec, but the spec itself says:
> "Not used for embeddings - embeddings do not support streaming"

This unused response type causes Speakeasy to generate:
```typescript
type CreateEmbeddingsResponse = CreateEmbeddingsResponseBody | string;
```

Which forces developers to write unnecessary type guards:
```typescript
if (typeof embedding === "string") {
  throw new Error("Invalid embedding response");  // Never happens
}
```

## Changes

Removed the unused `text/event-stream` response from `.speakeasy/in.openapi.yaml`.

## After Regeneration

After regenerating with Speakeasy, the type will be:
```typescript
type CreateEmbeddingsResponse = CreateEmbeddingsResponseBody;
```

Allowing clean access: `response.data[0].embedding`

## Note

This PR only updates the OpenAPI spec. The maintainers will need to regenerate with Speakeasy to update the TypeScript types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)