### PR TITLE
feat: add real-time streaming for generator tool preliminary results

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,8 @@ export {
 } from './lib/stream-transformers.js';
 // Tool creation helpers
 export { tool } from './lib/tool.js';
+// Real-time tool event broadcasting
+export { ToolEventBroadcaster } from './lib/tool-event-broadcaster.js';
 export {
   hasApprovalRequiredTools,
   hasExecuteFunction,

--- a/src/lib/tool-event-broadcaster.ts
+++ b/src/lib/tool-event-broadcaster.ts
@@ -1,0 +1,151 @@
+/**
+ * A push-based event broadcaster that supports multiple concurrent consumers.
+ * Similar to ReusableReadableStream but for push-based events from tool execution.
+ *
+ * Each consumer gets their own position in the buffer and receives all events
+ * from their join point onward. This enables real-time streaming of generator
+ * tool preliminary results to multiple consumers simultaneously.
+ *
+ * @template T - The event type being broadcast
+ */
+export class ToolEventBroadcaster<T> {
+  private buffer: T[] = [];
+  private consumers = new Map<number, ConsumerState>();
+  private nextConsumerId = 0;
+  private isComplete = false;
+  private completionError: Error | null = null;
+
+  /**
+   * Push a new event to all consumers.
+   * Events are buffered so late-joining consumers can catch up.
+   */
+  push(event: T): void {
+    if (this.isComplete) return;
+    this.buffer.push(event);
+    this.notifyWaitingConsumers();
+  }
+
+  /**
+   * Mark the broadcaster as complete - no more events will be pushed.
+   * Optionally pass an error to signal failure to all consumers.
+   */
+  complete(error?: Error): void {
+    this.isComplete = true;
+    this.completionError = error ?? null;
+    this.notifyWaitingConsumers();
+  }
+
+  /**
+   * Create a new consumer that can independently iterate over events.
+   * Consumers can join at any time and will receive events from position 0.
+   * Multiple consumers can be created and will all receive the same events.
+   */
+  createConsumer(): AsyncIterableIterator<T> {
+    const consumerId = this.nextConsumerId++;
+    const state: ConsumerState = {
+      position: 0,
+      waitingPromise: null,
+      cancelled: false,
+    };
+    this.consumers.set(consumerId, state);
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+
+    return {
+      async next(): Promise<IteratorResult<T>> {
+        const consumer = self.consumers.get(consumerId);
+        if (!consumer) {
+          return { done: true, value: undefined };
+        }
+
+        if (consumer.cancelled) {
+          return { done: true, value: undefined };
+        }
+
+        // Return buffered event if available
+        if (consumer.position < self.buffer.length) {
+          const value = self.buffer[consumer.position]!;
+          consumer.position++;
+          return { done: false, value };
+        }
+
+        // If complete and caught up, we're done
+        if (self.isComplete) {
+          self.consumers.delete(consumerId);
+          if (self.completionError) {
+            throw self.completionError;
+          }
+          return { done: true, value: undefined };
+        }
+
+        // Set up waiting promise FIRST to avoid race condition
+        const waitPromise = new Promise<void>((resolve, reject) => {
+          consumer.waitingPromise = { resolve, reject };
+
+          // Immediately check if we should resolve after setting up promise
+          if (
+            self.isComplete ||
+            self.completionError ||
+            consumer.position < self.buffer.length
+          ) {
+            resolve();
+          }
+        });
+
+        await waitPromise;
+        consumer.waitingPromise = null;
+
+        // Recursively try again after waking up
+        return this.next();
+      },
+
+      async return(): Promise<IteratorResult<T>> {
+        const consumer = self.consumers.get(consumerId);
+        if (consumer) {
+          consumer.cancelled = true;
+          self.consumers.delete(consumerId);
+        }
+        return { done: true, value: undefined };
+      },
+
+      async throw(e?: unknown): Promise<IteratorResult<T>> {
+        const consumer = self.consumers.get(consumerId);
+        if (consumer) {
+          consumer.cancelled = true;
+          self.consumers.delete(consumerId);
+        }
+        throw e;
+      },
+
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+  }
+
+  /**
+   * Notify all waiting consumers that new data is available or stream completed
+   */
+  private notifyWaitingConsumers(): void {
+    for (const consumer of this.consumers.values()) {
+      if (consumer.waitingPromise) {
+        if (this.completionError) {
+          consumer.waitingPromise.reject(this.completionError);
+        } else {
+          consumer.waitingPromise.resolve();
+        }
+        consumer.waitingPromise = null;
+      }
+    }
+  }
+}
+
+interface ConsumerState {
+  position: number;
+  waitingPromise: {
+    resolve: () => void;
+    reject: (error: Error) => void;
+  } | null;
+  cancelled: boolean;
+}

--- a/tests/unit/tool-event-broadcaster.test.ts
+++ b/tests/unit/tool-event-broadcaster.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+import { ToolEventBroadcaster } from '../../src/lib/tool-event-broadcaster.js';
+
+describe('ToolEventBroadcaster', () => {
+  describe('single consumer', () => {
+    it('should deliver events to a single consumer', async () => {
+      const broadcaster = new ToolEventBroadcaster<number>();
+      const consumer = broadcaster.createConsumer();
+
+      broadcaster.push(1);
+      broadcaster.push(2);
+      broadcaster.push(3);
+      broadcaster.complete();
+
+      const results: number[] = [];
+      for await (const event of consumer) {
+        results.push(event);
+      }
+
+      expect(results).toEqual([1, 2, 3]);
+    });
+
+    it('should handle empty stream', async () => {
+      const broadcaster = new ToolEventBroadcaster<string>();
+      const consumer = broadcaster.createConsumer();
+
+      broadcaster.complete();
+
+      const results: string[] = [];
+      for await (const event of consumer) {
+        results.push(event);
+      }
+
+      expect(results).toEqual([]);
+    });
+
+    it('should handle consumer cancellation via return()', async () => {
+      const broadcaster = new ToolEventBroadcaster<number>();
+      const consumer = broadcaster.createConsumer();
+
+      broadcaster.push(1);
+      broadcaster.push(2);
+
+      // Get first value
+      const first = await consumer.next();
+      expect(first.done).toBe(false);
+      expect(first.value).toBe(1);
+
+      // Cancel consumer
+      await consumer.return!();
+
+      // Should be done now
+      const after = await consumer.next();
+      expect(after.done).toBe(true);
+    });
+  });
+
+  describe('multiple consumers', () => {
+    it('should deliver same events to multiple consumers', async () => {
+      const broadcaster = new ToolEventBroadcaster<string>();
+      const consumer1 = broadcaster.createConsumer();
+      const consumer2 = broadcaster.createConsumer();
+
+      broadcaster.push('a');
+      broadcaster.push('b');
+      broadcaster.complete();
+
+      const results1: string[] = [];
+      const results2: string[] = [];
+
+      await Promise.all([
+        (async () => {
+          for await (const e of consumer1) results1.push(e);
+        })(),
+        (async () => {
+          for await (const e of consumer2) results2.push(e);
+        })(),
+      ]);
+
+      expect(results1).toEqual(['a', 'b']);
+      expect(results2).toEqual(['a', 'b']);
+    });
+
+    it('should allow consumers at different read positions', async () => {
+      const broadcaster = new ToolEventBroadcaster<number>();
+      const consumer1 = broadcaster.createConsumer();
+
+      broadcaster.push(1);
+      broadcaster.push(2);
+
+      // Consumer 1 reads first event
+      const first = await consumer1.next();
+      expect(first.value).toBe(1);
+
+      // Consumer 2 joins after events pushed
+      const consumer2 = broadcaster.createConsumer();
+
+      broadcaster.push(3);
+      broadcaster.complete();
+
+      // Consumer 1 continues from position 1
+      const remaining1: number[] = [];
+      for await (const e of consumer1) remaining1.push(e);
+      expect(remaining1).toEqual([2, 3]);
+
+      // Consumer 2 gets all events from position 0
+      const all2: number[] = [];
+      for await (const e of consumer2) all2.push(e);
+      expect(all2).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('async waiting', () => {
+    it('should wait for events when consumer is ahead of buffer', async () => {
+      const broadcaster = new ToolEventBroadcaster<number>();
+      const consumer = broadcaster.createConsumer();
+
+      // Start consuming before events arrive
+      const consumePromise = (async () => {
+        const results: number[] = [];
+        for await (const event of consumer) {
+          results.push(event);
+        }
+        return results;
+      })();
+
+      // Push events after consumer starts waiting
+      await new Promise((r) => setTimeout(r, 10));
+      broadcaster.push(1);
+      await new Promise((r) => setTimeout(r, 10));
+      broadcaster.push(2);
+      broadcaster.complete();
+
+      const results = await consumePromise;
+      expect(results).toEqual([1, 2]);
+    });
+
+    it('should handle rapid push/consume interleaving', async () => {
+      const broadcaster = new ToolEventBroadcaster<number>();
+      const consumer = broadcaster.createConsumer();
+
+      const received: number[] = [];
+      const consumePromise = (async () => {
+        for await (const event of consumer) {
+          received.push(event);
+        }
+      })();
+
+      // Push events with minimal delay
+      for (let i = 0; i < 10; i++) {
+        broadcaster.push(i);
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      broadcaster.complete();
+
+      await consumePromise;
+      expect(received).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should propagate errors to consumers', async () => {
+      const broadcaster = new ToolEventBroadcaster<number>();
+      const consumer = broadcaster.createConsumer();
+
+      broadcaster.push(1);
+      broadcaster.complete(new Error('Test error'));
+
+      const results: number[] = [];
+      let caughtError: Error | null = null;
+
+      try {
+        for await (const event of consumer) {
+          results.push(event);
+        }
+      } catch (e) {
+        caughtError = e as Error;
+      }
+
+      expect(results).toEqual([1]);
+      expect(caughtError).not.toBeNull();
+      expect(caughtError!.message).toBe('Test error');
+    });
+
+    it('should propagate errors to waiting consumers', async () => {
+      const broadcaster = new ToolEventBroadcaster<number>();
+      const consumer = broadcaster.createConsumer();
+
+      // Start consuming (will wait)
+      const consumePromise = (async () => {
+        const results: number[] = [];
+        for await (const event of consumer) {
+          results.push(event);
+        }
+        return results;
+      })();
+
+      // Complete with error while consumer is waiting
+      await new Promise((r) => setTimeout(r, 10));
+      broadcaster.complete(new Error('Async error'));
+
+      await expect(consumePromise).rejects.toThrow('Async error');
+    });
+  });
+
+  describe('ignore after complete', () => {
+    it('should ignore pushes after complete', async () => {
+      const broadcaster = new ToolEventBroadcaster<number>();
+      const consumer = broadcaster.createConsumer();
+
+      broadcaster.push(1);
+      broadcaster.complete();
+      broadcaster.push(2); // Should be ignored
+
+      const results: number[] = [];
+      for await (const event of consumer) {
+        results.push(event);
+      }
+
+      expect(results).toEqual([1]);
+    });
+  });
+
+  describe('typed events', () => {
+    it('should work with typed tool events', async () => {
+      type ToolEvent =
+        | { type: 'delta'; content: string }
+        | { type: 'preliminary_result'; toolCallId: string; result: unknown };
+
+      const broadcaster = new ToolEventBroadcaster<ToolEvent>();
+      const consumer = broadcaster.createConsumer();
+
+      broadcaster.push({ type: 'delta', content: 'test' });
+      broadcaster.push({
+        type: 'preliminary_result',
+        toolCallId: 'call_123',
+        result: { progress: 50 },
+      });
+      broadcaster.complete();
+
+      const events: ToolEvent[] = [];
+      for await (const event of consumer) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual({ type: 'delta', content: 'test' });
+      expect(events[1]).toEqual({
+        type: 'preliminary_result',
+        toolCallId: 'call_123',
+        result: { progress: 50 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds real-time streaming of generator tool preliminary results as they yield, rather than batch-emitting after tool execution completes
- Introduces `ToolEventBroadcaster` class for push-based multi-consumer event delivery following the `ReusableReadableStream` pattern
- Updates `getToolStream()` and `getFullResponsesStream()` to deliver events in real-time

## Motivation
Similar to Vercel AI SDK v6's streaming preliminary tool outputs feature. This enables streaming UI updates during long-running tool operations - users can see progress as it happens rather than waiting for completion.

## Changes
- **New**: `src/lib/tool-event-broadcaster.ts` - Push-based broadcaster with buffering and multiple consumer support
- **Modified**: `src/lib/model-result.ts` - Added `executeToolsWithBroadcast()` method, updated stream methods
- **Export**: `ToolEventBroadcaster` exported for advanced use cases

## Usage
```typescript
const progressTool = tool({
  name: 'progress_task',
  inputSchema: z.object({ task: z.string() }),
  eventSchema: z.object({ progress: z.number() }),
  outputSchema: z.object({ completed: z.boolean() }),
  execute: async function* (params) {
    yield { progress: 25 };  // Streamed immediately!
    await doWork();
    yield { progress: 50 };  // Streamed immediately!
    yield { completed: true };
  },
});

// Consume real-time events
for await (const event of response.getToolStream()) {
  if (event.type === 'preliminary_result') {
    console.log(`Progress: ${event.result.progress}%`);
  }
}
```

## Test plan
- [x] Unit tests for `ToolEventBroadcaster` (11 tests covering single/multiple consumers, async waiting, error handling)
- [x] E2E tests for real-time streaming via `getToolStream()` and `getFullResponsesStream()`
- [x] All existing tests pass