### PR TITLE
fix: use zod/v4/core types for cross-version compatibility

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.0
   generationVersion: 2.788.4
-  releaseVersion: 0.3.11
-  configChecksum: cef53c8d1317cb3ef7f140d2e53bd7a0
+  releaseVersion: 0.3.12
+  configChecksum: cce50a3d7b5dd75b96087345547294f3
   repoURL: https://github.com/OpenRouterTeam/typescript-sdk.git
   installationURL: https://github.com/OpenRouterTeam/typescript-sdk
   published: true
 persistentEdits:
-  generation_id: a2ada765-9f3b-4659-b8b6-ed40269ea430
-  pristine_commit_hash: 984a52fad729045bce58eef97270470afb744196
-  pristine_tree_hash: 5e4ab5e188946409ef6e4571fe523f276fe7105f
+  generation_id: ca9052d3-98c2-4cac-95f7-d5037c0dbe8a
+  pristine_commit_hash: 91e5dcb2c14bb5516188d34ea90ff8bb70ac6fda
+  pristine_tree_hash: 6cb2daf107b33d67d26fd4a55bb2c65f4e2b7c76
 features:
   typescript:
     acceptHeaders: 2.81.2
@@ -1960,12 +1960,12 @@ trackedFiles:
     pristine_git_object: 410efafd6a7f50d91ccb87131fedbe0c3d47e15a
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:f1ea0044f9cd1074d554da2a6f1d66366d57215b
-    pristine_git_object: cacd2f7942fa4dad0f007c80aa05e57f8af49b7c
+    last_write_checksum: sha1:5bb82593180b988c5b2a17d2c742406d6a15d2db
+    pristine_git_object: 2f4e1f407044a746f0989cca539d84d85628d098
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:b2c8f1a9776d2997b4404711ee9aa80b79a065da
-    pristine_git_object: 0c7924af3d3a92ddf8286d18b5845d2ca0de020c
+    last_write_checksum: sha1:a6a094aee517b1fc79d3acfd87dae93903d910ea
+    pristine_git_object: 4167411f54231e9e8ba7ceb281f0d6ca19e724fb
   src/core.ts:
     id: f431fdbcd144
     last_write_checksum: sha1:5aa66b0b6a5964f3eea7f3098c2eb3c0ee9c0131
@@ -2088,8 +2088,8 @@ trackedFiles:
     pristine_git_object: a187e58707bdb726ca2aff74941efe7493422d4e
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:351edbf3be387f1947550fa5d5eb5dedb4a41d9a
-    pristine_git_object: cde57f6466fbde060f4e4601264df4c9153dc794
+    last_write_checksum: sha1:cac230b3f1bb71d76dcb98ded8be09ef79f726b0
+    pristine_git_object: 1b37b1e20c5fd2bce32406d1fac907d453f9e50a
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:eaac763b22717206a6199104e0403ed17a4e2711

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -33,10 +33,11 @@ generation:
     skipResponseBodyAssertions: false
   preApplyUnionDiscriminators: true
 typescript:
-  version: 0.3.11
+  version: 0.3.12
   acceptHeaderEnum: false
   additionalDependencies:
-    dependencies: {}
+    dependencies:
+      zod: ^3.25.0 || ^4.0.0
     devDependencies:
       '@types/node': ^22.13.12
       dotenv: ^16.4.7

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@openrouter/sdk",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/sdk",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "author": "OpenRouter",
   "description": "The OpenRouter TypeScript SDK is a type-safe toolkit for building AI applications with access to 300+ language models through a unified API.",
   "keywords": [
@@ -73,7 +73,6 @@
     "test:e2e": "vitest --run --project e2e",
     "test:watch": "vitest --watch --project unit"
   },
-  "peerDependencies": {},
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@types/node": "^22.13.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       zod:
         specifier: ^3.25.0 || ^4.0.0
-        version: 4.2.1
+        version: 4.3.5
     devDependencies:
       '@eslint/js':
         specifier: ^9.19.0
@@ -1049,8 +1049,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@4.2.1:
-    resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
+  zod@4.3.5:
+    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
 snapshots:
 
@@ -1981,4 +1981,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@4.2.1: {}
+  zod@4.3.5: {}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -72,7 +72,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "0.3.11",
+  sdkVersion: "0.3.12",
   genVersion: "2.788.4",
-  userAgent: "speakeasy-sdk/typescript 0.3.11 2.788.4 1.0.0 @openrouter/sdk",
+  userAgent: "speakeasy-sdk/typescript 0.3.12 2.788.4 1.0.0 @openrouter/sdk",
 } as const;

--- a/src/lib/tool-executor.ts
+++ b/src/lib/tool-executor.ts
@@ -1,4 +1,4 @@
-import type { ZodType } from 'zod';
+import type { $ZodType } from 'zod/v4/core';
 import type {
   APITool,
   Tool,
@@ -76,7 +76,7 @@ function isZodSchema(value: unknown): value is z4.ZodType {
  * The resulting schema is sanitized to remove metadata properties (like ~standard)
  * that would cause 400 errors with downstream providers.
  */
-export function convertZodToJsonSchema(zodSchema: ZodType): Record<string, unknown> {
+export function convertZodToJsonSchema(zodSchema: $ZodType): Record<string, unknown> {
   if (!isZodSchema(zodSchema)) {
     throw new Error('Invalid Zod schema provided');
   }
@@ -107,16 +107,16 @@ export function convertToolsToAPIFormat(tools: readonly Tool[]): APITool[] {
  * Validate tool input against Zod schema
  * @throws ZodError if validation fails
  */
-export function validateToolInput<T>(schema: ZodType<T>, args: unknown): T {
-  return schema.parse(args);
+export function validateToolInput<T>(schema: $ZodType<T>, args: unknown): T {
+  return z4.parse(schema, args);
 }
 
 /**
  * Validate tool output against Zod schema
  * @throws ZodError if validation fails
  */
-export function validateToolOutput<T>(schema: ZodType<T>, result: unknown): T {
-  return schema.parse(result);
+export function validateToolOutput<T>(schema: $ZodType<T>, result: unknown): T {
+  return z4.parse(schema, result);
 }
 
 /**

--- a/src/lib/tool-types.ts
+++ b/src/lib/tool-types.ts
@@ -1,4 +1,4 @@
-import type { ZodObject, ZodRawShape, ZodType, z } from 'zod';
+import type { $ZodObject, $ZodShape, $ZodType, infer as zodInfer } from 'zod/v4/core';
 import type * as models from '../models/index.js';
 import type { OpenResponsesStreamEvent } from '../models/index.js';
 import type { ModelResult } from './model-result.js';
@@ -61,25 +61,25 @@ export type NextTurnParamsFunctions<TInput> = {
 /**
  * Base tool function interface with inputSchema
  */
-export interface BaseToolFunction<TInput extends ZodObject<ZodRawShape>> {
+export interface BaseToolFunction<TInput extends $ZodObject<$ZodShape>> {
   name: string;
   description?: string;
   inputSchema: TInput;
-  nextTurnParams?: NextTurnParamsFunctions<z.infer<TInput>>;
+  nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
 }
 
 /**
  * Regular tool with synchronous or asynchronous execute function and optional outputSchema
  */
 export interface ToolFunctionWithExecute<
-  TInput extends ZodObject<ZodRawShape>,
-  TOutput extends ZodType = ZodType<unknown>,
+  TInput extends $ZodObject<$ZodShape>,
+  TOutput extends $ZodType = $ZodType<unknown>,
 > extends BaseToolFunction<TInput> {
   outputSchema?: TOutput;
   execute: (
-    params: z.infer<TInput>,
+    params: zodInfer<TInput>,
     context?: TurnContext,
-  ) => Promise<z.infer<TOutput>> | z.infer<TOutput>;
+  ) => Promise<zodInfer<TOutput>> | zodInfer<TOutput>;
 }
 
 /**
@@ -105,22 +105,22 @@ export interface ToolFunctionWithExecute<
  * ```
  */
 export interface ToolFunctionWithGenerator<
-  TInput extends ZodObject<ZodRawShape>,
-  TEvent extends ZodType = ZodType<unknown>,
-  TOutput extends ZodType = ZodType<unknown>,
+  TInput extends $ZodObject<$ZodShape>,
+  TEvent extends $ZodType = $ZodType<unknown>,
+  TOutput extends $ZodType = $ZodType<unknown>,
 > extends BaseToolFunction<TInput> {
   eventSchema: TEvent;
   outputSchema: TOutput;
   // Generator can yield both events (TEvent) and the final output (TOutput)
-  execute: (params: z.infer<TInput>, context?: TurnContext) => AsyncGenerator<z.infer<TEvent> | z.infer<TOutput>>;
+  execute: (params: zodInfer<TInput>, context?: TurnContext) => AsyncGenerator<zodInfer<TEvent> | zodInfer<TOutput>>;
 }
 
 /**
  * Manual tool without execute function - requires manual handling by developer
  */
 export interface ManualToolFunction<
-  TInput extends ZodObject<ZodRawShape>,
-  TOutput extends ZodType = ZodType<unknown>,
+  TInput extends $ZodObject<$ZodShape>,
+  TOutput extends $ZodType = $ZodType<unknown>,
 > extends BaseToolFunction<TInput> {
   outputSchema?: TOutput;
 }
@@ -129,8 +129,8 @@ export interface ManualToolFunction<
  * Tool with execute function (regular or generator)
  */
 export type ToolWithExecute<
-  TInput extends ZodObject<ZodRawShape> = ZodObject<ZodRawShape>,
-  TOutput extends ZodType = ZodType<unknown>,
+  TInput extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+  TOutput extends $ZodType = $ZodType<unknown>,
 > = {
   type: ToolType.Function;
   function: ToolFunctionWithExecute<TInput, TOutput>;
@@ -140,9 +140,9 @@ export type ToolWithExecute<
  * Tool with generator execute function
  */
 export type ToolWithGenerator<
-  TInput extends ZodObject<ZodRawShape> = ZodObject<ZodRawShape>,
-  TEvent extends ZodType = ZodType<unknown>,
-  TOutput extends ZodType = ZodType<unknown>,
+  TInput extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+  TEvent extends $ZodType = $ZodType<unknown>,
+  TOutput extends $ZodType = $ZodType<unknown>,
 > = {
   type: ToolType.Function;
   function: ToolFunctionWithGenerator<TInput, TEvent, TOutput>;
@@ -152,8 +152,8 @@ export type ToolWithGenerator<
  * Tool without execute function (manual handling)
  */
 export type ManualTool<
-  TInput extends ZodObject<ZodRawShape> = ZodObject<ZodRawShape>,
-  TOutput extends ZodType = ZodType<unknown>,
+  TInput extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+  TOutput extends $ZodType = $ZodType<unknown>,
 > = {
   type: ToolType.Function;
   function: ManualToolFunction<TInput, TOutput>;
@@ -163,16 +163,16 @@ export type ManualTool<
  * Union type of all enhanced tool types
  */
 export type Tool =
-  | ToolWithExecute<ZodObject<ZodRawShape>, ZodType<unknown>>
-  | ToolWithGenerator<ZodObject<ZodRawShape>, ZodType<unknown>, ZodType<unknown>>
-  | ManualTool<ZodObject<ZodRawShape>, ZodType<unknown>>;
+  | ToolWithExecute<$ZodObject<$ZodShape>, $ZodType<unknown>>
+  | ToolWithGenerator<$ZodObject<$ZodShape>, $ZodType<unknown>, $ZodType<unknown>>
+  | ManualTool<$ZodObject<$ZodShape>, $ZodType<unknown>>;
 
 /**
  * Extracts the input type from a tool definition
  */
 export type InferToolInput<T> = T extends { function: { inputSchema: infer S } }
-  ? S extends ZodType
-  ? z.infer<S>
+  ? S extends $ZodType
+  ? zodInfer<S>
   : unknown
   : unknown;
 
@@ -180,8 +180,8 @@ export type InferToolInput<T> = T extends { function: { inputSchema: infer S } }
  * Extracts the output type from a tool definition
  */
 export type InferToolOutput<T> = T extends { function: { outputSchema: infer S } }
-  ? S extends ZodType
-  ? z.infer<S>
+  ? S extends $ZodType
+  ? zodInfer<S>
   : unknown
   : unknown;
 
@@ -213,8 +213,8 @@ export type ToolExecutionResultUnion<T extends readonly Tool[]> = {
  * Returns `never` for non-generator tools
  */
 export type InferToolEvent<T> = T extends { function: { eventSchema: infer S } }
-  ? S extends ZodType
-  ? z.infer<S>
+  ? S extends $ZodType
+  ? zodInfer<S>
   : never
   : never;
 
@@ -274,10 +274,10 @@ export interface ToolExecutionResult<T extends Tool> {
   toolCallId: string;
   toolName: string;
   result: T extends ToolWithExecute<any, infer O> | ToolWithGenerator<any, any, infer O>
-  ? z.infer<O>
+  ? zodInfer<O>
   : unknown; // Final result (sent to model)
   preliminaryResults?: T extends ToolWithGenerator<any, infer E, any>
-  ? z.infer<E>[]
+  ? zodInfer<E>[]
   : undefined; // All yielded values from generator
   error?: Error;
 }

--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -1,4 +1,4 @@
-import type { ZodObject, ZodRawShape, ZodType, z } from "zod";
+import type { $ZodObject, $ZodShape, $ZodType, infer as zodInfer } from 'zod/v4/core';
 import {
   ToolType,
   type TurnContext,
@@ -12,26 +12,26 @@ import {
  * Configuration for a regular tool with outputSchema
  */
 type RegularToolConfigWithOutput<
-  TInput extends ZodObject<ZodRawShape>,
-  TOutput extends ZodType,
+  TInput extends $ZodObject<$ZodShape>,
+  TOutput extends $ZodType,
 > = {
   name: string;
   description?: string;
   inputSchema: TInput;
   outputSchema: TOutput;
   eventSchema?: undefined;
-  nextTurnParams?: NextTurnParamsFunctions<z.infer<TInput>>;
+  nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   execute: (
-    params: z.infer<TInput>,
+    params: zodInfer<TInput>,
     context?: TurnContext
-  ) => Promise<z.infer<TOutput>> | z.infer<TOutput>;
+  ) => Promise<zodInfer<TOutput>> | zodInfer<TOutput>;
 };
 
 /**
  * Configuration for a regular tool without outputSchema (infers return type from execute)
  */
 type RegularToolConfigWithoutOutput<
-  TInput extends ZodObject<ZodRawShape>,
+  TInput extends $ZodObject<$ZodShape>,
   TReturn,
 > = {
   name: string;
@@ -39,9 +39,9 @@ type RegularToolConfigWithoutOutput<
   inputSchema: TInput;
   outputSchema?: undefined;
   eventSchema?: undefined;
-  nextTurnParams?: NextTurnParamsFunctions<z.infer<TInput>>;
+  nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   execute: (
-    params: z.infer<TInput>,
+    params: zodInfer<TInput>,
     context?: TurnContext
   ) => Promise<TReturn> | TReturn;
 };
@@ -50,37 +50,37 @@ type RegularToolConfigWithoutOutput<
  * Configuration for a generator tool (with eventSchema)
  */
 type GeneratorToolConfig<
-  TInput extends ZodObject<ZodRawShape>,
-  TEvent extends ZodType,
-  TOutput extends ZodType,
+  TInput extends $ZodObject<$ZodShape>,
+  TEvent extends $ZodType,
+  TOutput extends $ZodType,
 > = {
   name: string;
   description?: string;
   inputSchema: TInput;
   eventSchema: TEvent;
   outputSchema: TOutput;
-  nextTurnParams?: NextTurnParamsFunctions<z.infer<TInput>>;
+  nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   execute: (
-    params: z.infer<TInput>,
+    params: zodInfer<TInput>,
     context?: TurnContext
-  ) => AsyncGenerator<z.infer<TEvent> | z.infer<TOutput>>;
+  ) => AsyncGenerator<zodInfer<TEvent> | zodInfer<TOutput>>;
 };
 
 /**
  * Configuration for a manual tool (execute: false, no eventSchema or outputSchema)
  */
-type ManualToolConfig<TInput extends ZodObject<ZodRawShape>> = {
+type ManualToolConfig<TInput extends $ZodObject<$ZodShape>> = {
   name: string;
   description?: string;
   inputSchema: TInput;
-  nextTurnParams?: NextTurnParamsFunctions<z.infer<TInput>>;
+  nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   execute: false;
 };
 
 /**
  * Union type for all regular tool configs
  */
-type RegularToolConfig<TInput extends ZodObject<ZodRawShape>, TOutput extends ZodType, TReturn> =
+type RegularToolConfig<TInput extends $ZodObject<$ZodShape>, TOutput extends $ZodType, TReturn> =
   | RegularToolConfigWithOutput<TInput, TOutput>
   | RegularToolConfigWithoutOutput<TInput, TReturn>;
 
@@ -88,9 +88,9 @@ type RegularToolConfig<TInput extends ZodObject<ZodRawShape>, TOutput extends Zo
  * Type guard to check if config is a generator tool config (has eventSchema)
  */
 function isGeneratorConfig<
-  TInput extends ZodObject<ZodRawShape>,
-  TEvent extends ZodType,
-  TOutput extends ZodType,
+  TInput extends $ZodObject<$ZodShape>,
+  TEvent extends $ZodType,
+  TOutput extends $ZodType,
   TReturn,
 >(
   config:
@@ -104,9 +104,9 @@ function isGeneratorConfig<
 /**
  * Type guard to check if config is a manual tool config (execute === false)
  */
-function isManualConfig<TInput extends ZodObject<ZodRawShape>, TOutput extends ZodType, TReturn>(
+function isManualConfig<TInput extends $ZodObject<$ZodShape>, TOutput extends $ZodType, TReturn>(
   config:
-    | GeneratorToolConfig<TInput, ZodType, ZodType>
+    | GeneratorToolConfig<TInput, $ZodType, $ZodType>
     | RegularToolConfig<TInput, TOutput, TReturn>
     | ManualToolConfig<TInput>
 ): config is ManualToolConfig<TInput> {
@@ -160,35 +160,35 @@ function isManualConfig<TInput extends ZodObject<ZodRawShape>, TOutput extends Z
  */
 // Overload for generator tools (when eventSchema is provided)
 export function tool<
-  TInput extends ZodObject<ZodRawShape>,
-  TEvent extends ZodType,
-  TOutput extends ZodType,
+  TInput extends $ZodObject<$ZodShape>,
+  TEvent extends $ZodType,
+  TOutput extends $ZodType,
 >(
   config: GeneratorToolConfig<TInput, TEvent, TOutput>
 ): ToolWithGenerator<TInput, TEvent, TOutput>;
 
 // Overload for manual tools (execute: false)
-export function tool<TInput extends ZodObject<ZodRawShape>>(
+export function tool<TInput extends $ZodObject<$ZodShape>>(
   config: ManualToolConfig<TInput>
 ): ManualTool<TInput>;
 
 // Overload for regular tools with outputSchema
 export function tool<
-  TInput extends ZodObject<ZodRawShape>,
-  TOutput extends ZodType,
+  TInput extends $ZodObject<$ZodShape>,
+  TOutput extends $ZodType,
 >(config: RegularToolConfigWithOutput<TInput, TOutput>): ToolWithExecute<TInput, TOutput>;
 
 // Overload for regular tools without outputSchema (infers return type)
 export function tool<
-  TInput extends ZodObject<ZodRawShape>,
+  TInput extends $ZodObject<$ZodShape>,
   TReturn,
->(config: RegularToolConfigWithoutOutput<TInput, TReturn>): ToolWithExecute<TInput, ZodType<TReturn>>;
+>(config: RegularToolConfigWithoutOutput<TInput, TReturn>): ToolWithExecute<TInput, $ZodType<TReturn>>;
 
 // Implementation
 export function tool<
-  TInput extends ZodObject<ZodRawShape>,
-  TEvent extends ZodType,
-  TOutput extends ZodType,
+  TInput extends $ZodObject<$ZodShape>,
+  TEvent extends $ZodType,
+  TOutput extends $ZodType,
   TReturn,
 >(
   config:
@@ -198,7 +198,7 @@ export function tool<
 ):
   | ToolWithGenerator<TInput, TEvent, TOutput>
   | ToolWithExecute<TInput, TOutput>
-  | ToolWithExecute<TInput, ZodType<TReturn>>
+  | ToolWithExecute<TInput, $ZodType<TReturn>>
   | ManualTool<TInput> {
   // Check for manual tool first (execute === false)
   if (isManualConfig(config)) {


### PR DESCRIPTION
## Summary

Fixes TypeScript type errors when users have a different Zod 4.x minor version than the SDK. The error manifests as:

```
Type 'ZodString' is not assignable to type '$ZodType<...>'.
  The types of '_zod.version.minor' are incompatible between these types.
    Type '3' is not assignable to type '2'.
```

This follows [Zod's library author guide](https://zod.dev/library-authors) by using `$ZodType`, `$ZodObject`, and `$ZodShape` from `zod/v4/core` which are stable across all Zod 4.x versions.