### PR TITLE
feat(ci): add Copybara sync workflow for monorepo integration

### DIFF
--- a/.github/workflows/copybara-sync.yaml
+++ b/.github/workflows/copybara-sync.yaml
@@ -1,0 +1,30 @@
+name: Copybara Sync to Monorepo
+
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # For PRs, checkout the PR head to sync the actual changes
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Sync to Monorepo
+        uses: olivr/copybara-action@v1.2.5
+        with:
+          ssh_key: ${{ secrets.COPYBARA_SSH_KEY }}
+          access_token: ${{ secrets.MONOREPO_SYNC_TOKEN }}
+          sot_repo: OpenRouterTeam/typescript-sdk
+          destination_repo: OpenRouterTeam/openrouter-web
+          workflow: push
+          push_move: '||sdks/typescript||**'
+          push_exclude: '.github/workflows/copybara-sync.yaml'
+          # For PRs, create a PR in monorepo; for pushes to main, push directly
+          copybara_options: ${{ github.event_name == 'pull_request_target' && '--force' || '' }}


### PR DESCRIPTION
## Summary
Adds Copybara sync workflow to mirror changes from this SDK repo back to the monorepo.

## Behavior
- **PRs**: Creates a corresponding PR in the monorepo
- **Pushes to main**: Syncs merged changes to monorepo

## Secrets Required
- `COPYBARA_SSH_KEY` - SSH key for Copybara (already added)
- `MONOREPO_SYNC_TOKEN` - PAT with repo access to openrouter-web (needs to be added)