### PR TITLE
fix: allow null usage in ChatStreamChunk schema for streaming responses

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -12186,7 +12186,9 @@ components:
             message: Rate limit exceeded
             code: 429
         usage:
-          $ref: '#/components/schemas/ChatUsage'
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ChatUsage'
       required:
         - id
         - choices

--- a/src/models/chatstreamchunk.ts
+++ b/src/models/chatstreamchunk.ts
@@ -70,7 +70,7 @@ export type ChatStreamChunk = {
   /**
    * Token usage statistics
    */
-  usage?: ChatUsage | undefined;
+  usage?: ChatUsage | null | undefined;
 };
 
 /** @internal */
@@ -107,7 +107,7 @@ export const ChatStreamChunk$inboundSchema: z.ZodType<
   system_fingerprint: z.string().optional(),
   service_tier: z.nullable(z.string()).optional(),
   error: z.lazy(() => ErrorT$inboundSchema).optional(),
-  usage: ChatUsage$inboundSchema.optional(),
+  usage: z.nullable(ChatUsage$inboundSchema).optional(),
 }).transform((v) => {
   return remap$(v, {
     "system_fingerprint": "systemFingerprint",

--- a/tests/unit/issue-452-streaming-usage-null.test.ts
+++ b/tests/unit/issue-452-streaming-usage-null.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression test for GitHub issue #452
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/452
+ * (Moved from OpenRouterTeam/typescript-sdk#146)
+ *
+ * Reported error: ZodError invalid_union — "Invalid input: expected object, received null"
+ * on response.usage path when streaming
+ *
+ * This test verifies that streaming schemas accept usage: null,
+ * since early streaming events (e.g. response.created) and intermediate
+ * chat completion chunks may have usage: null before final usage is available.
+ */
+import { describe, it, expect } from 'vitest';
+import { ChatStreamChunk$inboundSchema } from '../../src/models/chatstreamchunk.js';
+import { StreamEvents$inboundSchema } from '../../src/models/streamevents.js';
+
+describe('Issue #452: streaming usage field accepts null', () => {
+  describe('ChatStreamChunk schema', () => {
+    it('should accept usage: null in a streaming chat completion chunk', () => {
+      const chunk = {
+        id: 'chatcmpl-test123',
+        choices: [
+          {
+            index: 0,
+            delta: { content: 'Hello' },
+            finish_reason: null,
+          },
+        ],
+        created: 1712345678,
+        model: 'anthropic/claude-sonnet-4.5',
+        object: 'chat.completion.chunk',
+        usage: null,
+      };
+
+      const result = ChatStreamChunk$inboundSchema.parse(chunk);
+      expect(result.id).toBe('chatcmpl-test123');
+      expect(result.usage).toBeNull();
+    });
+
+    it('should accept usage: undefined in a streaming chat completion chunk', () => {
+      const chunk = {
+        id: 'chatcmpl-test456',
+        choices: [
+          {
+            index: 0,
+            delta: { content: 'World' },
+            finish_reason: null,
+          },
+        ],
+        created: 1712345678,
+        model: 'anthropic/claude-sonnet-4.5',
+        object: 'chat.completion.chunk',
+      };
+
+      const result = ChatStreamChunk$inboundSchema.parse(chunk);
+      expect(result.id).toBe('chatcmpl-test456');
+      expect(result.usage).toBeUndefined();
+    });
+
+    it('should accept a valid usage object in a streaming chat completion chunk', () => {
+      const chunk = {
+        id: 'chatcmpl-test789',
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+        created: 1712345678,
+        model: 'anthropic/claude-sonnet-4.5',
+        object: 'chat.completion.chunk',
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      };
+
+      const result = ChatStreamChunk$inboundSchema.parse(chunk);
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.promptTokens).toBe(10);
+      expect(result.usage?.completionTokens).toBe(20);
+      expect(result.usage?.totalTokens).toBe(30);
+    });
+  });
+
+  describe('StreamEvents schema (Responses API)', () => {
+    it('should accept usage: null in a response.created event', () => {
+      const event = {
+        type: 'response.created',
+        response: {
+          id: 'resp_test123',
+          object: 'response',
+          created_at: 1712345678,
+          model: 'anthropic/claude-sonnet-4.5',
+          status: 'in_progress',
+          completed_at: null,
+          output: [],
+          error: null,
+          incomplete_details: null,
+          usage: null,
+          temperature: 1,
+          top_p: 1,
+          presence_penalty: 0,
+          frequency_penalty: 0,
+          instructions: null,
+          metadata: null,
+          tools: [],
+          tool_choice: 'auto',
+          parallel_tool_calls: true,
+        },
+        sequence_number: 0,
+      };
+
+      const result = StreamEvents$inboundSchema.parse(event);
+      expect(result.type).toBe('response.created');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `ChatStreamChunk` Zod schema rejected `usage: null` in streaming chat completion chunks, causing a `ZodError` (`invalid_type: expected object, received null`) that prevented consuming streams entirely. The API sends `usage: null` in intermediate streaming chunks before final usage data is available.

**Fix:** Changed `usage` from `.optional()` to `.nullable().optional()` in both the OpenAPI spec and the generated schema, so it now accepts `null | undefined | ChatUsage`.

The Responses API path (`OpenResponsesResult`) already handled `usage: null` correctly — only the Chat Completions streaming path was affected.

Fixes OpenRouterTeam/ai-sdk-provider#452 (moved from OpenRouterTeam/typescript-sdk#146)

## Review & Testing Checklist for Human

- [ ] Verify the OpenAPI spec change (`allOf` + `nullable: true` pattern) will produce the correct output when Speakeasy regenerates — this is the standard OpenAPI 3.0 nullable-ref pattern, but confirm it matches what Speakeasy expects
- [ ] Confirm no downstream SDK consumers rely on `usage` being strictly `ChatUsage | undefined` (never `null`) — e.g., code doing `=== undefined` checks instead of falsy checks

### Notes
- The generated file (`src/models/chatstreamchunk.ts`) was edited directly alongside the OpenAPI spec. Speakeasy's persistent edits mechanism should preserve this via 3-way merge on regeneration.
- The Responses API `StreamEvents` schema already accepted `usage: null` (confirmed by test) — this was only broken on the Chat Completions streaming path.

Link to Devin session: https://app.devin.ai/sessions/e3b2cbc5fbfe4b7499f581cb30795525
Requested by: @robert-j-y