### PR TITLE
Fix duplicate rootDir in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,6 @@
     "sourceMap": true,
     "rootDir": "src",
     "outDir": "esm",
-    "rootDir": "src",
-    
 
     // https://github.com/tsconfig/bases/blob/a1bf7c0fa2e094b068ca3e1448ca2ece4157977e/bases/strictest.json
     "strict": true,


### PR DESCRIPTION
## Summary
- remove the duplicate `rootDir` entry from `tsconfig.json`
- avoids Bun warning about duplicate object keys when the package tsconfig is parsed

## Verification
- confirmed `tsconfig.json` now contains one `rootDir` entry