### PR TITLE
fix(sdk): flatten STT/TTS request bodies via Speakeasy overlay

### DIFF
--- a/.speakeasy/overlays/flatten-stt-tts.overlay.yaml
+++ b/.speakeasy/overlays/flatten-stt-tts.overlay.yaml
@@ -1,0 +1,14 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Flatten STT and TTS request bodies
+  version: 0.0.0
+actions:
+  - target: $.paths["/audio/transcriptions"].post
+    description: Flatten createTranscription request body (max-method-params=1)
+    update:
+      x-speakeasy-max-method-params: 1
+  - target: $.paths["/audio/speech"].post
+    description: Flatten createSpeech request body (max-method-params=1)
+    update:
+      x-speakeasy-max-method-params: 1

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -11,6 +11,7 @@ sources:
             - location: .speakeasy/overlays/allof-simplify.overlay.yaml
             - location: .speakeasy/overlays/boolean-query-params.overlay.yaml
             - location: .speakeasy/overlays/nullable-model-fields.overlay.yaml
+            - location: .speakeasy/overlays/flatten-stt-tts.overlay.yaml
         output: .speakeasy/out.openapi.yaml
         registry:
             location: registry.speakeasyapi.dev/openrouter/sdk/open-router-chat-completions-api


### PR DESCRIPTION
## Summary
- Adds a scoped `x-speakeasy-max-method-params: 1` overlay for the `/audio/transcriptions` and `/audio/speech` POST operations so the generated TypeScript SDK exposes them with flat request shapes instead of a wrapper arg.
- Global `maxMethodParams` stays at `0` so no other methods are affected.
- **BREAKING**: `openrouter.stt.createTranscription()` and `openrouter.tts.createSpeech()` callers no longer pass the `sttRequest` / `speechRequest` wrapper. These endpoints are new, so the blast radius is accepted.

Companion docs/quickstart update: OpenRouterTeam/openrouter-web#19953 — both PRs should merge together, and the SDK must be regenerated after merge.

## Test plan
- [ ] CI dry-run generation passes
- [ ] Regenerate SDK after merge and verify `stt.createTranscription()` / `tts.createSpeech()` accept flat args
- [ ] Spot-check other generated methods are unchanged