### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -21715,8 +21715,10 @@ tags:
     name: Rerank
   - description: Speech-to-text endpoints
     name: STT
+    x-displayName: Transcriptions
   - description: Text-to-speech endpoints
     name: TTS
+    x-displayName: Speech
   - description: Video Generation endpoints
     name: Video Generation
   - description: Workspaces endpoints


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/25413235329)