### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -6347,6 +6347,7 @@ components:
         analysis_models:
           - ~anthropic/claude-opus-latest
           - ~openai/gpt-latest
+          - ~google/gemini-pro-latest
         enabled: true
         id: fusion
         model: ~anthropic/claude-opus-latest
@@ -6356,10 +6357,11 @@ components:
             Slugs of models to run in parallel as the "expert panel" the judge analyzes. Each model receives the same
             user prompt with web_search + web_fetch enabled. Capped at 8 models to bound cost amplification. When
             omitted, defaults to the Quality preset from the /labs/fusion UI (~anthropic/claude-opus-latest,
-            ~openai/gpt-latest).
+            ~openai/gpt-latest, ~google/gemini-pro-latest).
           example:
             - ~anthropic/claude-opus-latest
             - ~openai/gpt-latest
+            - ~google/gemini-pro-latest
           items:
             type: string
           maxItems: 8
@@ -6407,6 +6409,7 @@ components:
         analysis_models:
           - ~anthropic/claude-opus-latest
           - ~openai/gpt-latest
+          - ~google/gemini-pro-latest
       properties:
         analysis_models:
           description: >-
@@ -6417,6 +6420,7 @@ components:
           example:
             - ~anthropic/claude-opus-latest
             - ~openai/gpt-latest
+            - ~google/gemini-pro-latest
           items:
             type: string
           maxItems: 8


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/25824435222)