### PR TITLE
chore: bump Speakeasy CLI to 1.763.2

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,7 +3,7 @@ id: ""
 management:
   docChecksum: f3e4c3d168511342a08ecaff2e9d1db6
   docVersion: 1.0.0
-  speakeasyVersion: 1.761.0
+  speakeasyVersion: 1.763.2
   generationVersion: 2.879.1
   releaseVersion: 0.12.64
   configChecksum: d36fef3f19146de3fb5bf465c5d3b4e5

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.761.0
+speakeasyVersion: 1.763.2
 sources:
     OpenRouter API:
         sourceNamespace: open-router-chat-completions-api
@@ -17,7 +17,7 @@ targets:
         codeSamplesRevisionDigest: sha256:51d979bf63f08fe4221597df8b5824dee70deb710fb8bd788839bd9d3734d041
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.761.0
+    speakeasyVersion: 1.763.2
     sources:
         OpenRouter API:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.761.0
+speakeasyVersion: 1.763.2
 sources:
     OpenRouter API:
         inputs:


### PR DESCRIPTION
## Summary
- Bumps pinned Speakeasy CLI from `1.761.0` → `1.763.2` (latest).
- Updates `.speakeasy/workflow.yaml`, `.speakeasy/workflow.lock`, and `.speakeasy/gen.lock` to keep them in sync.

No generated code (`src/`) was regenerated as part of this change — the release workflow will pick up the new version on the next `speakeasy run`.

## Test plan
- [ ] CI passes
- [ ] Next `speakeasy run` (release workflow) succeeds against 1.763.2
- [ ] Review any resulting generated diffs separately if needed