### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -16624,6 +16624,98 @@ components:
         - unknown
       example: fp16
       type: string
+    RankingsDailyItem:
+      example:
+        date: '2026-05-11'
+        model_permaslug: openai/gpt-4o-2024-05-13
+        total_tokens: '12345678'
+      properties:
+        date:
+          description: UTC calendar date the row is aggregated over (YYYY-MM-DD).
+          example: '2026-05-11'
+          type: string
+        model_permaslug:
+          description: >-
+            Model variant permaslug (e.g. `openai/gpt-4o-2024-05-13`, `openai/gpt-4o-2024-05-13:free`). Non-default
+            variants include a `:variant` suffix and are ranked as their own entry. The reserved value `other` denotes
+            the aggregated row covering every model outside the daily top 50 for that date — always sorted last within
+            its date.
+          example: openai/gpt-4o-2024-05-13
+          type: string
+        total_tokens:
+          description: >-
+            Sum of `prompt_tokens + completion_tokens` for the day, returned as a decimal string so 64-bit values are
+            not truncated.
+          example: '12345678'
+          type: string
+      required:
+        - date
+        - model_permaslug
+        - total_tokens
+      type: object
+    RankingsDailyMeta:
+      example:
+        as_of: '2026-05-12T02:00:00Z'
+        end_date: '2026-05-11'
+        start_date: '2026-04-12'
+        version: v1
+      properties:
+        as_of:
+          description: >-
+            ISO-8601 timestamp of when the response was generated. Reflects data-freshness because the underlying
+            materialized view continuously ingests upstream events.
+          example: '2026-05-12T02:00:00Z'
+          type: string
+        end_date:
+          description: Resolved end of the date window (UTC, inclusive).
+          example: '2026-05-11'
+          type: string
+        start_date:
+          description: Resolved start of the date window (UTC, inclusive).
+          example: '2026-04-12'
+          type: string
+        version:
+          description: Dataset version. Field names and grain are stable for the life of `v1`.
+          enum:
+            - v1
+          type: string
+      required:
+        - as_of
+        - version
+        - start_date
+        - end_date
+      type: object
+    RankingsDailyResponse:
+      example:
+        data:
+          - date: '2026-05-11'
+            model_permaslug: openai/gpt-4o-2024-05-13
+            total_tokens: '12345678'
+          - date: '2026-05-11'
+            model_permaslug: anthropic/claude-3.5-sonnet-20241022
+            total_tokens: '9876543'
+        meta:
+          as_of: '2026-05-12T02:00:00Z'
+          end_date: '2026-05-11'
+          start_date: '2026-04-12'
+          version: v1
+      properties:
+        data:
+          description: >-
+            Up to 51 rows per day — the top 50 public models by `total_tokens` for each UTC calendar date in the window,
+            plus one aggregated `other` row summing every model outside that top 50 (omitted when the long tail is
+            empty). Rows are sorted by `date` ascending, then by `total_tokens` descending, with `other` pinned last
+            within its date. Ties between real models break alphabetically on `model_permaslug` so the order is stable
+            across requests.
+          items:
+            $ref: '#/components/schemas/RankingsDailyItem'
+          type: array
+        meta:
+          $ref: '#/components/schemas/RankingsDailyMeta'
+      required:
+        - data
+        - meta
+      type: object
     ReasoningConfig:
       allOf:
         - $ref: '#/components/schemas/BaseReasoningConfig'
@@ -21253,6 +21345,127 @@ paths:
       x-fern-ignore: true
       x-speakeasy-ignore: true
       x-speakeasy-name-override: createCoinbaseCharge
+  /datasets/rankings-daily:
+    get:
+      description: |-
+        Returns the top 50 public models per day by total token usage on OpenRouter, plus a
+        single aggregated `other` row per day that sums every model outside that top 50.
+        Token totals are `prompt_tokens + completion_tokens`, matching the public rankings
+        chart on openrouter.ai/rankings.
+
+        Each row is a distinct `(date, model_permaslug)` pair. The `other` row uses the
+        reserved permaslug `other` and is always returned last within its date, so callers
+        can compute `top-50 traffic / total daily traffic` without a second request.
+
+        Authenticate with any valid OpenRouter API key (same key used for inference).
+        Rate-limited to 30 requests/minute per key and 500 requests/day per account.
+
+        When republishing or quoting this dataset, OpenRouter must be cited as:
+        "Source: OpenRouter (openrouter.ai/rankings), as of {as_of}."
+
+        Token counts come from each upstream provider's own tokenizer (Anthropic counts
+        are as reported by Anthropic, OpenAI counts are as reported by OpenAI, etc.), so
+        a token in one row is not directly comparable to a token in another row from a
+        different provider.
+      operationId: getRankingsDaily
+      parameters:
+        - description: >-
+            Start of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to 30 days before `end_date`. The dataset
+            begins at 2025-01-01; earlier values are clamped forward to that floor and the resolved value is echoed in
+            `meta.start_date`.
+          in: query
+          name: start_date
+          required: false
+          schema:
+            description: >-
+              Start of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to 30 days before `end_date`. The
+              dataset begins at 2025-01-01; earlier values are clamped forward to that floor and the resolved value is
+              echoed in `meta.start_date`.
+            example: '2026-04-12'
+            pattern: ^\d{4}-\d{2}-\d{2}$
+            type: string
+        - description: >-
+            End of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to the most recent completed UTC day. Must
+            be on or after 2025-01-01; earlier values are rejected with a 400.
+          in: query
+          name: end_date
+          required: false
+          schema:
+            description: >-
+              End of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to the most recent completed UTC day. Must
+              be on or after 2025-01-01; earlier values are rejected with a 400.
+            example: '2026-05-11'
+            pattern: ^\d{4}-\d{2}-\d{2}$
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                data:
+                  - date: '2026-05-11'
+                    model_permaslug: openai/gpt-4o-2024-05-13
+                    total_tokens: '12345678'
+                  - date: '2026-05-11'
+                    model_permaslug: anthropic/claude-3.5-sonnet-20241022
+                    total_tokens: '9876543'
+                  - date: '2026-05-11'
+                    model_permaslug: other
+                    total_tokens: '4321098'
+                meta:
+                  as_of: '2026-05-12T02:00:00Z'
+                  end_date: '2026-05-11'
+                  start_date: '2026-04-12'
+                  version: v1
+              schema:
+                $ref: '#/components/schemas/RankingsDailyResponse'
+          description: >-
+            Up to 51 rows per day — the top 50 public models by `total_tokens` plus a single aggregated `other` row
+            covering every model outside that top 50. Sorted by `date` ascending, then by `total_tokens` descending,
+            with `other` pinned last within its date.
+        '400':
+          content:
+            application/json:
+              example:
+                error:
+                  code: 400
+                  message: Invalid request parameters
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+          description: Bad Request - Invalid request parameters or malformed input
+        '401':
+          content:
+            application/json:
+              example:
+                error:
+                  code: 401
+                  message: Missing Authentication header
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+          description: Unauthorized - Authentication required or invalid credentials
+        '429':
+          content:
+            application/json:
+              example:
+                error:
+                  code: 429
+                  message: Rate limit exceeded
+              schema:
+                $ref: '#/components/schemas/TooManyRequestsResponse'
+          description: Too Many Requests - Rate limit exceeded
+        '500':
+          content:
+            application/json:
+              example:
+                error:
+                  code: 500
+                  message: Internal Server Error
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+          description: Internal Server Error - Unexpected server error
+      summary: Daily token totals for top 50 models
+      tags:
+        - Datasets
   /embeddings:
     post:
       description: Submits an embedding request to the embeddings router
@@ -27919,6 +28132,8 @@ tags:
     name: Chat
   - description: Credit management endpoints
     name: Credits
+  - description: Datasets endpoints
+    name: Datasets
   - description: Text embedding endpoints
     name: Embeddings
   - description: Endpoint information


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/26474793406)