### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -4464,9 +4464,10 @@ components:
           type: string
         session_id:
           description: >-
-            A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for
-            observability. If provided in both the request body and the x-session-id header, the body value takes
-            precedence. Maximum of 256 characters.
+            A unique identifier for grouping related requests (e.g., a conversation or agent workflow). When provided,
+            OpenRouter uses it as the sticky routing key, routing all requests in the session to the same provider to
+            maximize prompt cache hits. Also used for observability grouping. If provided in both the request body and
+            the x-session-id header, the body value takes precedence. Maximum of 256 characters.
           maxLength: 256
           type: string
         stop:
@@ -9957,9 +9958,10 @@ components:
           type: string
         session_id:
           description: >-
-            A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for
-            observability. If provided in both the request body and the x-session-id header, the body value takes
-            precedence. Maximum of 256 characters.
+            A unique identifier for grouping related requests (e.g., a conversation or agent workflow). When provided,
+            OpenRouter uses it as the sticky routing key, routing all requests in the session to the same provider to
+            maximize prompt cache hits. Also used for observability grouping. If provided in both the request body and
+            the x-session-id header, the body value takes precedence. Maximum of 256 characters.
           maxLength: 256
           type: string
         speed:
@@ -17353,9 +17355,10 @@ components:
           type: string
         session_id:
           description: >-
-            A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for
-            observability. If provided in both the request body and the x-session-id header, the body value takes
-            precedence. Maximum of 256 characters.
+            A unique identifier for grouping related requests (e.g., a conversation or agent workflow). When provided,
+            OpenRouter uses it as the sticky routing key, routing all requests in the session to the same provider to
+            maximize prompt cache hits. Also used for observability grouping. If provided in both the request body and
+            the x-session-id header, the body value takes precedence. Maximum of 256 characters.
           maxLength: 256
           type: string
         stop_server_tools_when:


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/26591845091)