### PR TITLE
publish: enable npm provenance via publishConfig

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -64,6 +64,9 @@ typescript:
       - llm
     license: Apache-2.0
     packageManager: pnpm@10.22.0
+    publishConfig:
+      access: public
+      provenance: true
   additionalScripts:
     compile: tsc
     postinstall: node scripts/check-types.js || true

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   ],
   "license": "Apache-2.0",
   "packageManager": "pnpm@10.22.0",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "type": "module",
   "main": "./esm/index.js",
   "exports": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Publishing `@openrouter/sdk` to npm has been failing since ~mid-May. The CI `npm publish` step fails, and after rotating to a correctly-scoped granular token the error changed to:

```
npm error code EOTP
npm error This operation requires a one-time password.
```

This confirms the token is authenticated and authorized — the wall is npm's **2FA-on-publish** requirement now enforced on the `@openrouter/sdk` package. Granular access tokens do **not** bypass 2FA by default.

By contrast, `@openrouter/agent` keeps publishing fine because it already publishes with **OIDC provenance** (`publishConfig: { access: "public", provenance: true }`), which is an allowed path under 2FA enforcement.

## Fix

Enable npm provenance for the SDK so publishes are attested via the GitHub Actions OIDC token, mirroring how `@openrouter/agent` already publishes:

- `package.json`: add `publishConfig: { access: "public", provenance: true }`
- `.speakeasy/gen.yaml`: add the same under `typescript.additionalPackageJSON` so the field is regenerated into `package.json` and **survives Speakeasy regeneration** (otherwise the next monorepo release would overwrite it)

The publish workflow (`.github/workflows/sdk_publish.yaml`) already has `id-token: write`, so no workflow change is required.

## Required one-time npm setup (out of band)

For OIDC/Trusted Publishing to authenticate without a token, the package must be configured as a Trusted Publisher on npm, and the record must match the workflow exactly:

- npmjs.com → `@openrouter/sdk` → Access → Trusted Publishers
- Publisher: GitHub Actions
- Repository owner: `OpenRouterTeam`
- Repository name: `typescript-sdk`
- Workflow filename: `sdk_publish.yaml`
- Environment name: **leave blank** — `sdk_publish.yaml` does not declare a deployment `environment:`. If the existing Trusted Publisher record sets `Environment: npm-publish`, the OIDC environment claim will not match and auth will fail. Either clear that field on the record, or add a matching `environment: npm-publish` to the publish job.

## Verification

After merge + Trusted Publisher reconciliation, re-run `sdk_publish.yaml` via `workflow_dispatch` on `main`. Expected: publish succeeds (no more `EOTP`) and `npm view @openrouter/sdk dist-tags.latest` returns the current version.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ed7a128-1e51-4049-a57d-3a14eb1832db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ed7a128-1e51-4049-a57d-3a14eb1832db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

