### PR TITLE
ci: dispatch agent bump on @openrouter/sdk publish

### DIFF
--- a/.github/workflows/dispatch-agent-bump.yaml
+++ b/.github/workflows/dispatch-agent-bump.yaml
@@ -63,10 +63,9 @@ jobs:
       - name: Dispatch to typescript-agent
         if: steps.dedupe.outputs.cache-hit != 'true'
         env:
-          # Reuse the org's established cross-repo PAT (the same token the
-          # monorepo uses to push into the SDK repos). Needs contents:write on
-          # OpenRouterTeam/typescript-agent to be accepted.
-          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
+          # Cross-repo PAT. Needs contents:write on
+          # OpenRouterTeam/typescript-agent so the repository_dispatch is accepted.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           set -euo pipefail
           gh api repos/OpenRouterTeam/typescript-agent/dispatches \

--- a/.github/workflows/dispatch-agent-bump.yaml
+++ b/.github/workflows/dispatch-agent-bump.yaml
@@ -63,7 +63,10 @@ jobs:
       - name: Dispatch to typescript-agent
         if: steps.dedupe.outputs.cache-hit != 'true'
         env:
-          GH_TOKEN: ${{ secrets.AGENT_DISPATCH_PAT }}
+          # Reuse the org's established cross-repo PAT (the same token the
+          # monorepo uses to push into the SDK repos). Needs contents:write on
+          # OpenRouterTeam/typescript-agent to be accepted.
+          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
         run: |
           set -euo pipefail
           gh api repos/OpenRouterTeam/typescript-agent/dispatches \

--- a/.github/workflows/dispatch-agent-bump.yaml
+++ b/.github/workflows/dispatch-agent-bump.yaml
@@ -1,0 +1,78 @@
+name: Dispatch Agent Bump
+
+# Fires the next hop in the SDK release chain. When @openrouter/sdk publishes a
+# new version to npm (the "Publish" workflow completes successfully), this sends
+# a repository_dispatch to OpenRouterTeam/typescript-agent so it can open a PR
+# bumping its @openrouter/sdk dependency.
+#
+# workflow_run only fires for workflow files that live on the default branch, so
+# this file must be merged to main before the automatic trigger is active. Use
+# the workflow_dispatch input to test or backfill a specific version by hand.
+
+on:
+  workflow_run:
+    workflows: ["Publish"] # must match the `name:` of sdk_publish.yaml exactly
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "@openrouter/sdk version to dispatch (blank = npm latest)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dispatch-agent-bump
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    # On workflow_run, only proceed when the upstream Publish actually succeeded.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve @openrouter/sdk version
+        id: ver
+        run: |
+          set -euo pipefail
+          V="${{ github.event.inputs.version }}"
+          if [ -z "$V" ]; then
+            V="$(npm view @openrouter/sdk version)"
+          fi
+          if [ -z "$V" ]; then
+            echo "::error::Could not resolve @openrouter/sdk version"
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Resolved @openrouter/sdk version: $V"
+
+      # Dedupe: a single published version should only ever dispatch once, even
+      # if the Publish workflow re-runs. The cache key encodes the version; a
+      # cache hit means we already dispatched this version.
+      - name: Check dispatch dedupe cache
+        id: dedupe
+        uses: actions/cache@v4
+        with:
+          path: .last-dispatched-sdk
+          key: dispatched-sdk-${{ steps.ver.outputs.version }}
+
+      - name: Dispatch to typescript-agent
+        if: steps.dedupe.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_DISPATCH_PAT }}
+        run: |
+          set -euo pipefail
+          gh api repos/OpenRouterTeam/typescript-agent/dispatches \
+            -f event_type=openrouter-sdk-published \
+            -F "client_payload[version]=${{ steps.ver.outputs.version }}" \
+            -F "client_payload[source_run_url]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "Dispatched openrouter-sdk-published (version ${{ steps.ver.outputs.version }}) to typescript-agent"
+          echo "${{ steps.ver.outputs.version }}" > .last-dispatched-sdk
+
+      - name: Skipped (already dispatched)
+        if: steps.dedupe.outputs.cache-hit == 'true'
+        run: echo "Version ${{ steps.ver.outputs.version }} was already dispatched — skipping"


### PR DESCRIPTION
## Dispatch agent bump on `@openrouter/sdk` publish (HOP 1 of the SDK release chain)

Part of automating SDK version propagation across the three repos. When the
**Publish** workflow finishes (a new `@openrouter/sdk` lands on npm), this fires
a `repository_dispatch` (`openrouter-sdk-published`) to `typescript-agent`, which
opens a PR bumping its `@openrouter/sdk` dependency.

### What this adds
- `.github/workflows/dispatch-agent-bump.yaml` — `workflow_run` listener on
  **Publish** (success) + a `workflow_dispatch` backfill input. Resolves the
  version (input or `npm view`), dedupes per-version via `actions/cache`, and
  dispatches using the existing **`SUBTREE_PUSH_PAT`**.

### Secrets — reuses existing, nothing new to create
- **`SUBTREE_PUSH_PAT`** — the org's established cross-repo PAT (already used by
  the monorepo to push into the SDK repos). ⚠️ Only requirement: confirm this
  PAT's scope includes **`contents: write` on `OpenRouterTeam/typescript-agent`**
  so the cross-repo `repository_dispatch` is accepted. If it's org-level it
  already resolves here; if it's repo-level on the monorepo only, copy it to
  this repo (or widen its scope).

### Activation note
`workflow_run` only fires for workflows on the **default branch** — the automatic
trigger activates only **after this is merged to `main`**. Until then, test via
the `workflow_dispatch` version input.

### How to test
1. Merge to `main`.
2. Actions → **Dispatch Agent Bump** → Run workflow → enter a known version (e.g. `0.12.79`).
3. Confirm a `Bump @openrouter/sdk` run appears on `typescript-agent`.

[sdk-bot]
