### PR TITLE
fix: use PR mode for spec-change SDK generation

### DIFF
--- a/.github/workflows/sdk_generation_for_spec_change.yaml
+++ b/.github/workflows/sdk_generation_for_spec_change.yaml
@@ -28,7 +28,7 @@ jobs:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
       force: ${{ github.event.inputs.force }}
-      mode: direct
+      mode: pr
       pnpm_version: "10.22.0"
       set_version: ${{ github.event.inputs.set_version }}
     secrets:


### PR DESCRIPTION
Switch sdk_generation_for_spec_change.yaml from direct to pr mode so Speakeasy opens a PR instead of publishing directly. This routes npm publishing through sdk_publish.yaml, which has the correct Trusted Publisher configuration.