### PR TITLE
fix: match Speakeasy regen PRs by bot author, not login

### DIFF
--- a/.github/workflows/auto-merge-speakeasy-pr.yaml
+++ b/.github/workflows/auto-merge-speakeasy-pr.yaml
@@ -66,7 +66,7 @@ jobs:
               (.headRefName | startswith("speakeasy-sdk-regen-"))
               and (.title | contains("🐝 Update SDK"))
               and ([.labels[].name] | any(. == "patch" or . == "minor" or . == "major"))
-              and (.author.login == "github-actions[bot]")
+              and (.author.is_bot == true)
             ' > /dev/null; then
               PR_NUM=$(echo "$CANDIDATE" | jq -r '.number')
               echo "Resolved Speakeasy regen PR #$PR_NUM from branch $BRANCH"
@@ -81,7 +81,7 @@ jobs:
                 | select(.headRefName | startswith("speakeasy-sdk-regen-"))
                 | select(.title | contains("🐝 Update SDK"))
                 | select([.labels[].name] | any(. == "patch" or . == "minor" or . == "major"))
-                | select(.author.login == "github-actions[bot]")
+                | select(.author.is_bot == true)
                 | select(.updatedAt >= $started)
               ] | sort_by(.updatedAt) | last | .number // empty')
           fi


### PR DESCRIPTION
## Summary
- Fixes auto-merge PR resolution so Speakeasy regen PRs are found again
- Replaces `author.login == "github-actions[bot]"` with `author.is_bot == true` in both branch_name and run_started_at paths
- GitHub now reports these PRs as `app/github-actions`, which caused #486 auto-merge to skip every qualifying PR

## Test plan
- [ ] Merge this PR
- [ ] Close stale open `speakeasy-sdk-regen-*` PRs if needed (e.g. #482, #484)
- [ ] Dispatch **Generate** on `main`
- [ ] Confirm `resolve-branch` extracts `branch_name` and `auto-merge` resolves PR #N (not "auto-merge skipped")
- [ ] Confirm regen PR is squash-merged and **Publish** runs