### PR TITLE
chore: temporarily disable Speakeasy auto-merge steps (SDK-466)

### DIFF
--- a/.github/workflows/auto-merge-speakeasy-pr.yaml
+++ b/.github/workflows/auto-merge-speakeasy-pr.yaml
@@ -33,195 +33,202 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve Speakeasy regen PR
-        id: pr
-        env:
-          PAT: ${{ secrets.gh_token }}
-          FALLBACK_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if [ -n "$PAT" ]; then
-            export GH_TOKEN="$PAT"
-          else
-            echo "::warning::gh_token secret not set — using GITHUB_TOKEN (Publish push trigger may be suppressed)"
-            export GH_TOKEN="$FALLBACK_TOKEN"
-          fi
+      # TODO(SDK-466): re-enable the steps below once the GH PAT issues are
+      # resolved. The PAT is required so the merge commit triggers the
+      # downstream sdk_publish.yaml push workflow; with only GITHUB_TOKEN the
+      # publish trigger is suppressed.
+      - name: Auto-merge disabled
+        run: echo "Speakeasy regen PR resolution + auto-merge temporarily disabled pending GH PAT fix (SDK-466)"
 
-          REPO="${{ github.repository }}"
-          RUN_STARTED="${{ inputs.run_started_at }}"
-          BRANCH="${{ inputs.branch_name }}"
-
-          PR_JSON=$(gh pr list \
-            --repo "$REPO" \
-            --state open \
-            --search "head:speakeasy-sdk-regen-" \
-            --limit 500 \
-            --json number,updatedAt,title,labels,author,headRefName)
-
-          PR_NUM=""
-          if [ -n "$BRANCH" ]; then
-            CANDIDATE=$(echo "$PR_JSON" | jq -r --arg branch "$BRANCH" \
-              '[.[] | select(.headRefName == $branch)] | .[0] // empty')
-            if [ -n "$CANDIDATE" ] && echo "$CANDIDATE" | jq -e '
-              (.headRefName | startswith("speakeasy-sdk-regen-"))
-              and (.title | contains("🐝 Update SDK"))
-              and ([.labels[].name] | any(. == "patch" or . == "minor" or . == "major"))
-              and (.author.is_bot == true)
-            ' > /dev/null; then
-              PR_NUM=$(echo "$CANDIDATE" | jq -r '.number')
-              echo "Resolved Speakeasy regen PR #$PR_NUM from branch $BRANCH"
-            else
-              echo "::warning::branch_name=$BRANCH did not match a valid open regen PR — falling back to run_started_at"
-            fi
-          fi
-
-          if [ -z "$PR_NUM" ]; then
-            PR_NUM=$(echo "$PR_JSON" | jq -r --arg started "$RUN_STARTED" '
-              [.[]
-                | select(.headRefName | startswith("speakeasy-sdk-regen-"))
-                | select(.title | contains("🐝 Update SDK"))
-                | select([.labels[].name] | any(. == "patch" or . == "minor" or . == "major"))
-                | select(.author.is_bot == true)
-                | select(.updatedAt >= $started)
-              ] | sort_by(.updatedAt) | last | .number // empty')
-          fi
-
-          if [ -z "$PR_NUM" ]; then
-            echo "No Speakeasy regen PR for this Generate run — skipping auto-merge"
-            echo "::notice title=auto-merge-skipped::No qualifying Speakeasy regen PR to merge"
-            {
-              echo "## Auto-merge skipped"
-              echo "No qualifying \`speakeasy-sdk-regen-*\` PR was found."
-              echo "- branch_name input: \`${BRANCH:-<empty>}\`"
-              echo "- run_started_at: \`$RUN_STARTED\`"
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "pr_num=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
-          echo "$PR_JSON" > /tmp/speakeasy_pr_json.json
-
-      - name: Close superseded Speakeasy PRs
-        if: steps.pr.outputs.pr_num != ''
-        env:
-          PAT: ${{ secrets.gh_token }}
-          FALLBACK_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if [ -n "$PAT" ]; then
-            export GH_TOKEN="$PAT"
-          else
-            export GH_TOKEN="$FALLBACK_TOKEN"
-          fi
-
-          CURRENT_PR="${{ steps.pr.outputs.pr_num }}"
-          PR_JSON=$(cat /tmp/speakeasy_pr_json.json)
-
-          PRIOR_JSON=$(echo "$PR_JSON" | jq -r --arg current_pr "$CURRENT_PR" \
-            '[.[].number | select(tostring != $current_pr)] | .[]')
-
-          if [ -z "$PRIOR_JSON" ]; then
-            echo "No superseded Speakeasy PRs to close"
-            exit 0
-          fi
-
-          mapfile -t PRIOR <<< "$PRIOR_JSON"
-
-          echo "Closing ${#PRIOR[@]} superseded Speakeasy PR(s)"
-          for N in "${PRIOR[@]}"; do
-            gh pr close "$N" --repo "${{ github.repository }}" --delete-branch \
-              --comment "Superseded by newer Speakeasy SDK generation PR #${CURRENT_PR}" \
-              || echo "::warning::Failed to close PR #$N (continuing)"
-            sleep 1
-          done
-
-      - name: Auto-merge Speakeasy PR
-        if: steps.pr.outputs.pr_num != ''
-        env:
-          PAT: ${{ secrets.gh_token }}
-          FALLBACK_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if [ -n "$PAT" ]; then
-            export GH_TOKEN="$PAT"
-          else
-            export GH_TOKEN="$FALLBACK_TOKEN"
-          fi
-
-          PR_NUM="${{ steps.pr.outputs.pr_num }}"
-          REPO="${{ github.repository }}"
-
-          wait_for_checks() {
-            local pr=$1
-            local timeout=600
-            local interval=15
-            local elapsed=0
-
-            echo "Waiting for PR #$pr checks (timeout ${timeout}s)..."
-            while [ "$elapsed" -lt "$timeout" ]; do
-              TOTAL=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq \
-                '.statusCheckRollup | length')
-              PENDING=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq \
-                '[.statusCheckRollup[]? | select(.status != "COMPLETED")] | length')
-              FAILED=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq \
-                '[.statusCheckRollup[]? | select(.status == "COMPLETED") | select(.conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL")] | length')
-
-              if [ "$TOTAL" -eq 0 ]; then
-                echo "Checks not yet registered — waiting ${interval}s..."
-                sleep "$interval"
-                elapsed=$((elapsed + interval))
-                continue
-              fi
-
-              if [ "$PENDING" -eq 0 ]; then
-                if [ "$FAILED" -gt 0 ]; then
-                  echo "::error::PR #$pr has failing checks — refusing direct merge"
-                  gh pr checks "$pr" --repo "$REPO" || true
-                  exit 1
-                fi
-                echo "All checks completed"
-                return 0
-              fi
-
-              echo "Checks pending ($PENDING) — waiting ${interval}s..."
-              sleep "$interval"
-              elapsed=$((elapsed + interval))
-            done
-
-            echo "::error::Timed out waiting for PR #$pr checks"
-            exit 1
-          }
-
-          STATE=$(gh pr view "$PR_NUM" --repo "$REPO" --json state --jq .state)
-          if [ "$STATE" != "OPEN" ]; then
-            echo "PR #$PR_NUM is $STATE — skipping merge"
-            exit 0
-          fi
-
-          MERGE_METHOD=""
-          # Prefer GitHub auto-merge when required checks exist; otherwise
-          # squash-merge directly after checks pass (sdk-release-prs.yaml pattern).
-          AUTO_MERGE_NOOP_PATTERN='is in clean status|protected branch rules|Branch does not have required protected branch rules'
-          if gh pr merge "$PR_NUM" --repo "$REPO" --squash --auto --delete-branch 2> /tmp/gh-merge.err; then
-            MERGE_METHOD="auto-merge queued"
-            echo "Auto-merge enabled for Speakeasy PR #$PR_NUM"
-          elif grep -qiE "$AUTO_MERGE_NOOP_PATTERN" /tmp/gh-merge.err; then
-            echo "Auto-merge not applicable — waiting for checks, then merging PR #$PR_NUM directly"
-            cat /tmp/gh-merge.err >&2
-            wait_for_checks "$PR_NUM"
-            gh pr merge "$PR_NUM" --repo "$REPO" --squash --delete-branch
-            MERGE_METHOD="direct squash (checks passed)"
-          else
-            echo "::error::Failed to enable auto-merge on Speakeasy PR #$PR_NUM"
-            cat /tmp/gh-merge.err >&2
-            exit 1
-          fi
-
-          echo "::notice title=auto-merge-pr::Merged Speakeasy PR #$PR_NUM ($MERGE_METHOD)"
-          {
-            echo "## Auto-merge complete"
-            echo "- PR: #$PR_NUM"
-            echo "- Method: $MERGE_METHOD"
-            echo "- Token: $([ -n "$PAT" ] && echo 'PAT (gh_token)' || echo 'GITHUB_TOKEN (fallback)')"
-          } >> "$GITHUB_STEP_SUMMARY"
+      # - name: Resolve Speakeasy regen PR
+      #   id: pr
+      #   env:
+      #     PAT: ${{ secrets.gh_token }}
+      #     FALLBACK_TOKEN: ${{ github.token }}
+      #   run: |
+      #     set -euo pipefail
+      #     if [ -n "$PAT" ]; then
+      #       export GH_TOKEN="$PAT"
+      #     else
+      #       echo "::warning::gh_token secret not set — using GITHUB_TOKEN (Publish push trigger may be suppressed)"
+      #       export GH_TOKEN="$FALLBACK_TOKEN"
+      #     fi
+      #
+      #     REPO="${{ github.repository }}"
+      #     RUN_STARTED="${{ inputs.run_started_at }}"
+      #     BRANCH="${{ inputs.branch_name }}"
+      #
+      #     PR_JSON=$(gh pr list \
+      #       --repo "$REPO" \
+      #       --state open \
+      #       --search "head:speakeasy-sdk-regen-" \
+      #       --limit 500 \
+      #       --json number,updatedAt,title,labels,author,headRefName)
+      #
+      #     PR_NUM=""
+      #     if [ -n "$BRANCH" ]; then
+      #       CANDIDATE=$(echo "$PR_JSON" | jq -r --arg branch "$BRANCH" \
+      #         '[.[] | select(.headRefName == $branch)] | .[0] // empty')
+      #       if [ -n "$CANDIDATE" ] && echo "$CANDIDATE" | jq -e '
+      #         (.headRefName | startswith("speakeasy-sdk-regen-"))
+      #         and (.title | contains("🐝 Update SDK"))
+      #         and ([.labels[].name] | any(. == "patch" or . == "minor" or . == "major"))
+      #         and (.author.is_bot == true)
+      #       ' > /dev/null; then
+      #         PR_NUM=$(echo "$CANDIDATE" | jq -r '.number')
+      #         echo "Resolved Speakeasy regen PR #$PR_NUM from branch $BRANCH"
+      #       else
+      #         echo "::warning::branch_name=$BRANCH did not match a valid open regen PR — falling back to run_started_at"
+      #       fi
+      #     fi
+      #
+      #     if [ -z "$PR_NUM" ]; then
+      #       PR_NUM=$(echo "$PR_JSON" | jq -r --arg started "$RUN_STARTED" '
+      #         [.[]
+      #           | select(.headRefName | startswith("speakeasy-sdk-regen-"))
+      #           | select(.title | contains("🐝 Update SDK"))
+      #           | select([.labels[].name] | any(. == "patch" or . == "minor" or . == "major"))
+      #           | select(.author.is_bot == true)
+      #           | select(.updatedAt >= $started)
+      #         ] | sort_by(.updatedAt) | last | .number // empty')
+      #     fi
+      #
+      #     if [ -z "$PR_NUM" ]; then
+      #       echo "No Speakeasy regen PR for this Generate run — skipping auto-merge"
+      #       echo "::notice title=auto-merge-skipped::No qualifying Speakeasy regen PR to merge"
+      #       {
+      #         echo "## Auto-merge skipped"
+      #         echo "No qualifying \`speakeasy-sdk-regen-*\` PR was found."
+      #         echo "- branch_name input: \`${BRANCH:-<empty>}\`"
+      #         echo "- run_started_at: \`$RUN_STARTED\`"
+      #       } >> "$GITHUB_STEP_SUMMARY"
+      #       echo "pr_num=" >> "$GITHUB_OUTPUT"
+      #       exit 0
+      #     fi
+      #
+      #     echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
+      #     echo "$PR_JSON" > /tmp/speakeasy_pr_json.json
+      #
+      # - name: Close superseded Speakeasy PRs
+      #   if: steps.pr.outputs.pr_num != ''
+      #   env:
+      #     PAT: ${{ secrets.gh_token }}
+      #     FALLBACK_TOKEN: ${{ github.token }}
+      #   run: |
+      #     set -euo pipefail
+      #     if [ -n "$PAT" ]; then
+      #       export GH_TOKEN="$PAT"
+      #     else
+      #       export GH_TOKEN="$FALLBACK_TOKEN"
+      #     fi
+      #
+      #     CURRENT_PR="${{ steps.pr.outputs.pr_num }}"
+      #     PR_JSON=$(cat /tmp/speakeasy_pr_json.json)
+      #
+      #     PRIOR_JSON=$(echo "$PR_JSON" | jq -r --arg current_pr "$CURRENT_PR" \
+      #       '[.[].number | select(tostring != $current_pr)] | .[]')
+      #
+      #     if [ -z "$PRIOR_JSON" ]; then
+      #       echo "No superseded Speakeasy PRs to close"
+      #       exit 0
+      #     fi
+      #
+      #     mapfile -t PRIOR <<< "$PRIOR_JSON"
+      #
+      #     echo "Closing ${#PRIOR[@]} superseded Speakeasy PR(s)"
+      #     for N in "${PRIOR[@]}"; do
+      #       gh pr close "$N" --repo "${{ github.repository }}" --delete-branch \
+      #         --comment "Superseded by newer Speakeasy SDK generation PR #${CURRENT_PR}" \
+      #         || echo "::warning::Failed to close PR #$N (continuing)"
+      #       sleep 1
+      #     done
+      #
+      # - name: Auto-merge Speakeasy PR
+      #   if: steps.pr.outputs.pr_num != ''
+      #   env:
+      #     PAT: ${{ secrets.gh_token }}
+      #     FALLBACK_TOKEN: ${{ github.token }}
+      #   run: |
+      #     set -euo pipefail
+      #     if [ -n "$PAT" ]; then
+      #       export GH_TOKEN="$PAT"
+      #     else
+      #       export GH_TOKEN="$FALLBACK_TOKEN"
+      #     fi
+      #
+      #     PR_NUM="${{ steps.pr.outputs.pr_num }}"
+      #     REPO="${{ github.repository }}"
+      #
+      #     wait_for_checks() {
+      #       local pr=$1
+      #       local timeout=600
+      #       local interval=15
+      #       local elapsed=0
+      #
+      #       echo "Waiting for PR #$pr checks (timeout ${timeout}s)..."
+      #       while [ "$elapsed" -lt "$timeout" ]; do
+      #         TOTAL=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq \
+      #           '.statusCheckRollup | length')
+      #         PENDING=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq \
+      #           '[.statusCheckRollup[]? | select(.status != "COMPLETED")] | length')
+      #         FAILED=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq \
+      #           '[.statusCheckRollup[]? | select(.status == "COMPLETED") | select(.conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL")] | length')
+      #
+      #         if [ "$TOTAL" -eq 0 ]; then
+      #           echo "Checks not yet registered — waiting ${interval}s..."
+      #           sleep "$interval"
+      #           elapsed=$((elapsed + interval))
+      #           continue
+      #         fi
+      #
+      #         if [ "$PENDING" -eq 0 ]; then
+      #           if [ "$FAILED" -gt 0 ]; then
+      #             echo "::error::PR #$pr has failing checks — refusing direct merge"
+      #             gh pr checks "$pr" --repo "$REPO" || true
+      #             exit 1
+      #           fi
+      #           echo "All checks completed"
+      #           return 0
+      #         fi
+      #
+      #         echo "Checks pending ($PENDING) — waiting ${interval}s..."
+      #         sleep "$interval"
+      #         elapsed=$((elapsed + interval))
+      #       done
+      #
+      #       echo "::error::Timed out waiting for PR #$pr checks"
+      #       exit 1
+      #     }
+      #
+      #     STATE=$(gh pr view "$PR_NUM" --repo "$REPO" --json state --jq .state)
+      #     if [ "$STATE" != "OPEN" ]; then
+      #       echo "PR #$PR_NUM is $STATE — skipping merge"
+      #       exit 0
+      #     fi
+      #
+      #     MERGE_METHOD=""
+      #     # Prefer GitHub auto-merge when required checks exist; otherwise
+      #     # squash-merge directly after checks pass (sdk-release-prs.yaml pattern).
+      #     AUTO_MERGE_NOOP_PATTERN='is in clean status|protected branch rules|Branch does not have required protected branch rules'
+      #     if gh pr merge "$PR_NUM" --repo "$REPO" --squash --auto --delete-branch 2> /tmp/gh-merge.err; then
+      #       MERGE_METHOD="auto-merge queued"
+      #       echo "Auto-merge enabled for Speakeasy PR #$PR_NUM"
+      #     elif grep -qiE "$AUTO_MERGE_NOOP_PATTERN" /tmp/gh-merge.err; then
+      #       echo "Auto-merge not applicable — waiting for checks, then merging PR #$PR_NUM directly"
+      #       cat /tmp/gh-merge.err >&2
+      #       wait_for_checks "$PR_NUM"
+      #       gh pr merge "$PR_NUM" --repo "$REPO" --squash --delete-branch
+      #       MERGE_METHOD="direct squash (checks passed)"
+      #     else
+      #       echo "::error::Failed to enable auto-merge on Speakeasy PR #$PR_NUM"
+      #       cat /tmp/gh-merge.err >&2
+      #       exit 1
+      #     fi
+      #
+      #     echo "::notice title=auto-merge-pr::Merged Speakeasy PR #$PR_NUM ($MERGE_METHOD)"
+      #     {
+      #       echo "## Auto-merge complete"
+      #       echo "- PR: #$PR_NUM"
+      #       echo "- Method: $MERGE_METHOD"
+      #       echo "- Token: $([ -n "$PAT" ] && echo 'PAT (gh_token)' || echo 'GITHUB_TOKEN (fallback)')"
+      #     } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Comment out the `Resolve Speakeasy regen PR`, `Close superseded Speakeasy PRs`, and `Auto-merge Speakeasy PR` steps in `auto-merge-speakeasy-pr.yaml`.
- Replace with a stub step (jobs need at least one step) and a `TODO(SDK-466)` note explaining the steps will be re-enabled once the GH PAT issue blocking the downstream `sdk_publish.yaml` push trigger is fixed.

Tracked in SDK-466.

## Test plan
- [ ] Trigger a Speakeasy regen flow and confirm the `auto-merge` job runs the stub step and exits clean
- [ ] Confirm no regen PRs are auto-closed or auto-merged while the steps are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)