### PR TITLE
fix: correct gh --jq syntax in resolve-branch job

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -58,7 +58,7 @@ jobs:
 
           RUN_STARTED="${{ github.run_started_at }}"
           if [ -z "$RUN_STARTED" ]; then
-            RUN_STARTED=$(gh run view "$RUN_ID" --repo "$REPO" --json startedAt --jq -r .startedAt)
+            RUN_STARTED=$(gh run view "$RUN_ID" --repo "$REPO" --json startedAt --jq '.startedAt')
             echo "Resolved run_started_at from API: $RUN_STARTED"
           fi
           echo "run_started_at=$RUN_STARTED" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sdk_generation_for_spec_change.yaml
+++ b/.github/workflows/sdk_generation_for_spec_change.yaml
@@ -59,7 +59,7 @@ jobs:
 
           RUN_STARTED="${{ github.run_started_at }}"
           if [ -z "$RUN_STARTED" ]; then
-            RUN_STARTED=$(gh run view "$RUN_ID" --repo "$REPO" --json startedAt --jq -r .startedAt)
+            RUN_STARTED=$(gh run view "$RUN_ID" --repo "$REPO" --json startedAt --jq '.startedAt')
             echo "Resolved run_started_at from API: $RUN_STARTED"
           fi
           echo "run_started_at=$RUN_STARTED" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fixes `resolve-branch` crash: `gh run view --jq -r .startedAt` → `--jq '.startedAt'`
- Unblocks `run_started_at` capture and downstream auto-merge inputs

Addresses failure in Generate run #28067493396 (`accepts at most 1 arg(s), received 2`).

## Test plan
- [ ] Merge this PR
- [ ] Confirm GH_DOCS_SYNC secrets on typescript-sdk
- [ ] Dispatch **Generate** on `main`
- [ ] Confirm `resolve-branch` completes and auto-merge runs