### PR TITLE
ci: dispatch openrouter-sdk-published to openrouter-web

### DIFF
--- a/.github/workflows/dispatch-agent-bump.yaml
+++ b/.github/workflows/dispatch-agent-bump.yaml
@@ -88,4 +88,6 @@ jobs:
 
       - name: Skipped (already dispatched)
         if: steps.dedupe.outputs.cache-hit == 'true'
-        run: echo "Version ${{ steps.ver.outputs.version }} was already dispatched — skipping"
+        env:
+          DISPATCHED_VERSION: ${{ steps.ver.outputs.version }}
+        run: echo "Version ${DISPATCHED_VERSION} was already dispatched — skipping"

--- a/.github/workflows/dispatch-agent-bump.yaml
+++ b/.github/workflows/dispatch-agent-bump.yaml
@@ -37,9 +37,11 @@ jobs:
     steps:
       - name: Resolve @openrouter/sdk version
         id: ver
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
-          V="${{ github.event.inputs.version }}"
+          V="$INPUT_VERSION"
           if [ -z "$V" ]; then
             V="$(npm view @openrouter/sdk version)"
           fi
@@ -73,14 +75,16 @@ jobs:
         if: steps.dedupe.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DISPATCH_VERSION: ${{ steps.ver.outputs.version }}
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           gh api repos/OpenRouterTeam/typescript-agent/dispatches \
             -f event_type=openrouter-sdk-published \
-            -F "client_payload[version]=${{ steps.ver.outputs.version }}" \
-            -F "client_payload[source_run_url]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "Dispatched openrouter-sdk-published (version ${{ steps.ver.outputs.version }}) to typescript-agent"
-          echo "${{ steps.ver.outputs.version }}" > .last-dispatched-sdk
+            -F "client_payload[version]=${DISPATCH_VERSION}" \
+            -F "client_payload[source_run_url]=${SOURCE_RUN_URL}"
+          echo "Dispatched openrouter-sdk-published (version ${DISPATCH_VERSION}) to typescript-agent"
+          echo "${DISPATCH_VERSION}" > .last-dispatched-sdk
 
       - name: Skipped (already dispatched)
         if: steps.dedupe.outputs.cache-hit == 'true'

--- a/.github/workflows/dispatch-monorepo-sdk-bump.yaml
+++ b/.github/workflows/dispatch-monorepo-sdk-bump.yaml
@@ -1,0 +1,88 @@
+name: Dispatch Monorepo SDK Bump
+
+# HOP A→monorepo: when @openrouter/sdk publishes a new version to npm (the
+# "Publish" workflow completes successfully), this sends a repository_dispatch
+# to OpenRouterTeam/openrouter-web so it can open a PR bumping its pinned
+# @openrouter/sdk dependency. Complements dispatch-agent-bump.yaml (which
+# notifies typescript-agent).
+#
+# workflow_run only fires for workflow files that live on the default branch, so
+# this file must be merged to main before the automatic trigger is active. Use
+# the workflow_dispatch input to test or backfill a specific version by hand.
+
+on:
+  workflow_run:
+    workflows: ["Publish"] # must match the `name:` of sdk_publish.yaml exactly
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "@openrouter/sdk version to dispatch (blank = npm latest)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dispatch-monorepo-sdk-bump
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    # On workflow_run, only proceed when the upstream Publish actually succeeded.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve @openrouter/sdk version
+        id: ver
+        run: |
+          set -euo pipefail
+          V="${{ github.event.inputs.version }}"
+          if [ -z "$V" ]; then
+            V="$(npm view @openrouter/sdk version)"
+          fi
+          if [ -z "$V" ]; then
+            echo "::error::Could not resolve @openrouter/sdk version"
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Resolved @openrouter/sdk version: $V"
+
+      # Dedupe: a single published version should only ever dispatch once, even
+      # if the Publish workflow re-runs. The cache key encodes the version; a
+      # cache hit means we already dispatched this version.
+      - name: Check dispatch dedupe cache
+        id: dedupe
+        uses: actions/cache@v4
+        with:
+          path: .last-dispatched-monorepo-sdk
+          key: dispatched-monorepo-sdk-${{ steps.ver.outputs.version }}
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_DOCS_SYNC_APP_ID }}
+          private-key: ${{ secrets.GH_DOCS_SYNC_APP_PRIVATE_KEY }}
+          owner: OpenRouterTeam
+          repositories: openrouter-web
+
+      - name: Dispatch to openrouter-web
+        if: steps.dedupe.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh api repos/OpenRouterTeam/openrouter-web/dispatches \
+            -f event_type=openrouter-sdk-published \
+            -F "client_payload[version]=${{ steps.ver.outputs.version }}" \
+            -F "client_payload[source_run_url]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "Dispatched openrouter-sdk-published (version ${{ steps.ver.outputs.version }}) to openrouter-web"
+          echo "${{ steps.ver.outputs.version }}" > .last-dispatched-monorepo-sdk
+
+      - name: Skipped (already dispatched)
+        if: steps.dedupe.outputs.cache-hit == 'true'
+        run: echo "Version ${{ steps.ver.outputs.version }} was already dispatched to openrouter-web — skipping"

--- a/.github/workflows/dispatch-monorepo-sdk-bump.yaml
+++ b/.github/workflows/dispatch-monorepo-sdk-bump.yaml
@@ -38,9 +38,11 @@ jobs:
     steps:
       - name: Resolve @openrouter/sdk version
         id: ver
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
-          V="${{ github.event.inputs.version }}"
+          V="$INPUT_VERSION"
           if [ -z "$V" ]; then
             V="$(npm view @openrouter/sdk version)"
           fi
@@ -74,14 +76,16 @@ jobs:
         if: steps.dedupe.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DISPATCH_VERSION: ${{ steps.ver.outputs.version }}
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           gh api repos/OpenRouterTeam/openrouter-web/dispatches \
             -f event_type=openrouter-sdk-published \
-            -F "client_payload[version]=${{ steps.ver.outputs.version }}" \
-            -F "client_payload[source_run_url]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "Dispatched openrouter-sdk-published (version ${{ steps.ver.outputs.version }}) to openrouter-web"
-          echo "${{ steps.ver.outputs.version }}" > .last-dispatched-monorepo-sdk
+            -F "client_payload[version]=${DISPATCH_VERSION}" \
+            -F "client_payload[source_run_url]=${SOURCE_RUN_URL}"
+          echo "Dispatched openrouter-sdk-published (version ${DISPATCH_VERSION}) to openrouter-web"
+          echo "${DISPATCH_VERSION}" > .last-dispatched-monorepo-sdk
 
       - name: Skipped (already dispatched)
         if: steps.dedupe.outputs.cache-hit == 'true'

--- a/.github/workflows/dispatch-monorepo-sdk-bump.yaml
+++ b/.github/workflows/dispatch-monorepo-sdk-bump.yaml
@@ -89,4 +89,6 @@ jobs:
 
       - name: Skipped (already dispatched)
         if: steps.dedupe.outputs.cache-hit == 'true'
-        run: echo "Version ${{ steps.ver.outputs.version }} was already dispatched to openrouter-web — skipping"
+        env:
+          DISPATCHED_VERSION: ${{ steps.ver.outputs.version }}
+        run: echo "Version ${DISPATCHED_VERSION} was already dispatched to openrouter-web — skipping"


### PR DESCRIPTION
## Summary

- Add `dispatch-monorepo-sdk-bump.yaml` workflow that fires after the Publish workflow succeeds
- Dispatches `openrouter-sdk-published` to `OpenRouterTeam/openrouter-web` so the monorepo can bump its pinned `@openrouter/sdk` dependency
- Mirrors the existing `dispatch-agent-bump.yaml` pattern (dedupe cache, GitHub App token, manual `workflow_dispatch` for backfill)

## Companion PR

- https://github.com/OpenRouterTeam/openrouter-web/pull/27171

## Test plan

- [ ] Merge openrouter-web PR first (or in parallel) so `bump-openrouter-deps` listens for `openrouter-sdk-published`
- [ ] Merge this PR to main so `workflow_run` trigger is active
- [ ] Run `workflow_dispatch` with a test version and confirm openrouter-web Actions receives the dispatch