### PR TITLE
fix: skip app token generation when dispatch dedupe cache hits

### DIFF
--- a/.github/workflows/dispatch-monorepo-sdk-bump.yaml
+++ b/.github/workflows/dispatch-monorepo-sdk-bump.yaml
@@ -64,6 +64,7 @@ jobs:
           key: dispatched-monorepo-sdk-${{ steps.ver.outputs.version }}
 
       - name: Generate GitHub App token
+        if: steps.dedupe.outputs.cache-hit != 'true'
         id: app-token
         uses: actions/create-github-app-token@v3
         with:


### PR DESCRIPTION
## TL;DR

Skip GitHub App token generation when the monorepo SDK dispatch dedupe cache already hit, so token failures cannot fail a no-op run.

## What changed?

- Add `if: steps.dedupe.outputs.cache-hit != 'true'` to the "Generate GitHub App token" step in `dispatch-monorepo-sdk-bump.yaml`.

## Why?

The dispatch step was already gated on cache miss, but token generation ran unconditionally. If app credentials were invalid or rate-limited, the workflow would fail even when the version had already been dispatched and no dispatch was needed.

## How to test

- Trigger `Dispatch Monorepo SDK Bump` via `workflow_dispatch` with a version that was already dispatched → expect the "Skipped (already dispatched)" path without generating a token.
- Trigger with a new version → expect token generation and dispatch as before.

## Reviewer focus

- Confirm the `if` condition matches the dispatch step guard (`cache-hit != 'true'`).

## Related work

- Companion change in openrouter-web PR #27171 (template at `scripts/release-automation/upstream-dispatch-monorepo-sdk-bump.yaml`).