### PR TITLE
test(e2e): update models.list() tests for paginated PageIterator response

### DIFF
--- a/tests/e2e/models.test.ts
+++ b/tests/e2e/models.test.ts
@@ -21,14 +21,14 @@ describe('Models E2E Tests', () => {
 
       expect(response).toBeDefined();
 
-      expect(Array.isArray(response.data)).toBe(true);
-      expect(response.data.length).toBeGreaterThan(0);
+      expect(Array.isArray(response.result.data)).toBe(true);
+      expect(response.result.data.length).toBeGreaterThan(0);
     });
 
     it('should return models with expected properties', async () => {
       const response = await client.models.list();
 
-      const firstModel = response.data[0];
+      const firstModel = response.result.data[0];
       expect(firstModel).toBeDefined();
       expect(firstModel?.id).toBeDefined();
       expect(typeof firstModel?.id).toBe('string');


### PR DESCRIPTION
## Summary
Since SDK 0.13.45 (#588, spec change from OpenRouterTeam/openrouter-web#27246 adding `x-speakeasy-pagination` to `getModels`), `models.list()` returns a `PageIterator<GetModelsResponse>` shaped `{ result, next }` instead of `ModelsListResponse` (`{ data }`). The e2e tests still read `response.data`, so every sdk-bot PR's `run-speakeasy` job has been failing (e.g. #599) on a failure that also reproduces on `main`.

Update `tests/e2e/models.test.ts` to read models from `response.result.data`.

Verified locally: `npx vitest run tests/e2e/models.test.ts` → 3 passed.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/f0fba49ae1974fe999cb73a7ae53ea40
Requested by: @christineschen