### PR TITLE
fix(docs): replace invalid default OpenRouter import with named import

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -7,7 +7,7 @@ The OpenRouter TypeScript SDK is a type-safe toolkit for building AI application
 Integrating AI models into applications involves handling different provider APIs, managing model-specific requirements, and avoiding common implementation mistakes. The OpenRouter SDK standardizes these integrations and protects you from footguns.
 
 ```typescript
-import OpenRouter from '@openrouter/sdk';
+import { OpenRouter } from '@openrouter/sdk';
 
 const client = new OpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY
@@ -84,7 +84,7 @@ Get your API key from [openrouter.ai/settings/keys](https://openrouter.ai/settin
 ## Quick start
 
 ```typescript
-import OpenRouter from '@openrouter/sdk';
+import { OpenRouter } from '@openrouter/sdk';
 
 const client = new OpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY


### PR DESCRIPTION
## Changes

- Replaced the incorrect default import (`import OpenRouter from "@openrouter/sdk"`) with the correct named import (`import { OpenRouter } from "@openrouter/sdk"`) in `OVERVIEW.md`.

## Why

The package does not expose a default export.

This can be verified by following the export chain:

- [`src/sdk/sdk.ts`](https://github.com/OpenRouterTeam/typescript-sdk/blob/main/src/sdk/sdk.ts#L46) declares `OpenRouter` as a named export via `export class OpenRouter`.
- [`src/index.ts`](https://github.com/OpenRouterTeam/typescript-sdk/blob/main/src/index.ts#L10) re-exports it with `export * from "./sdk/sdk.js"`, which only re-exports named exports.
- Neither `src/sdk/sdk.ts` nor `src/index.ts` defines or re-exports a `default` export.

As a result, `import OpenRouter from "@openrouter/sdk"` is invalid, while `import { OpenRouter } from "@openrouter/sdk"` matches the package's public API.