### PR TITLE
fix: reject duplicate/conflicting approval decision ids

### DIFF
--- a/src/lib/async-params.ts
+++ b/src/lib/async-params.ts
@@ -74,9 +74,15 @@ type BaseCallModelInput<
 type ApprovalParamsWithState<TTools extends readonly Tool[] = readonly Tool[]> = {
   /** State accessor for multi-turn persistence and approval gates */
   state: StateAccessor<TTools>;
-  /** Tool call IDs to approve (for resuming from awaiting_approval status) */
+  /**
+   * Tool call IDs to approve (for resuming from awaiting_approval status).
+   * IDs must be distinct within this array and disjoint from rejectToolCalls.
+   */
   approveToolCalls?: string[];
-  /** Tool call IDs to reject (for resuming from awaiting_approval status) */
+  /**
+   * Tool call IDs to reject (for resuming from awaiting_approval status).
+   * IDs must be distinct within this array and disjoint from approveToolCalls.
+   */
   rejectToolCalls?: string[];
 };
 

--- a/src/lib/model-result.ts
+++ b/src/lib/model-result.ts
@@ -221,6 +221,64 @@ export class ModelResult<
     this.requireApprovalFn = options.requireApproval ?? null;
     this.approvedToolCalls = options.approveToolCalls ?? [];
     this.rejectedToolCalls = options.rejectToolCalls ?? [];
+    this.validateApprovalDecisions();
+  }
+
+  /**
+   * Validate approval-decision arrays for intra-array duplicates and for ids
+   * that appear in both approveToolCalls and rejectToolCalls.
+   *
+   * Throws synchronously so malformed input surfaces at the callModel /
+   * ModelResult entry point — before any tool executes or state is mutated.
+   * Approval is a security boundary; an ambiguous decision set is a caller
+   * bug and must not be silently resolved.
+   */
+  private validateApprovalDecisions(): void {
+    const findDuplicates = (ids: string[]): string[] => {
+      const seen = new Set<string>();
+      const dupes = new Set<string>();
+      for (const id of ids) {
+        if (seen.has(id)) {
+          dupes.add(id);
+        } else {
+          seen.add(id);
+        }
+      }
+      return [...dupes];
+    };
+
+    const approveDupes = findDuplicates(this.approvedToolCalls);
+    const rejectDupes = findDuplicates(this.rejectedToolCalls);
+    const approveSet = new Set(this.approvedToolCalls);
+    const conflicts = [
+      ...new Set(this.rejectedToolCalls.filter((id) => approveSet.has(id))),
+    ];
+
+    if (
+      approveDupes.length === 0 &&
+      rejectDupes.length === 0 &&
+      conflicts.length === 0
+    ) {
+      return;
+    }
+
+    const problems: string[] = [];
+    if (approveDupes.length > 0) {
+      problems.push(`duplicate id(s) in approveToolCalls: ${approveDupes.join(', ')}`);
+    }
+    if (rejectDupes.length > 0) {
+      problems.push(`duplicate id(s) in rejectToolCalls: ${rejectDupes.join(', ')}`);
+    }
+    if (conflicts.length > 0) {
+      problems.push(
+        `id(s) present in both approveToolCalls and rejectToolCalls: ${conflicts.join(', ')}`,
+      );
+    }
+
+    throw new Error(
+      `Invalid approval decisions: ${problems.join('; ')}. ` +
+        `Each tool call id may appear at most once, and a tool call cannot be both approved and rejected.`,
+    );
   }
 
   /**

--- a/tests/unit/issue-518-approval-dedup.test.ts
+++ b/tests/unit/issue-518-approval-dedup.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import type { OpenRouterCore } from '../../src/core.js';
+import { ModelResult, type GetResponseOptions } from '../../src/lib/model-result.js';
+import { tool } from '../../src/lib/tool.js';
+import type { ConversationState, StateAccessor } from '../../src/lib/tool-types.js';
+
+/**
+ * Regression tests for GitHub issue #518: Approval decisions must be
+ * de-duplicated / conflict-free.
+ *
+ * Malformed decision arrays (duplicate ids, or an id in both approve and
+ * reject) throw synchronously at ModelResult construction — before any tool
+ * executes or state is mutated.
+ *
+ * Happy-path cases keep a second untouched pending call (`call_2`) so
+ * `processApprovalDecisions()` returns before `continueWithUnsentResults()`
+ * would make a real API request. This keeps the suite fully offline.
+ */
+
+function makeAwaitingApprovalState(): ConversationState<readonly [ReturnType<typeof tool>]> {
+  const now = Date.now();
+  return {
+    id: 'conv_test_518',
+    messages: [{ role: 'user', content: 'please run the tool' }],
+    status: 'awaiting_approval',
+    pendingToolCalls: [
+      { id: 'call_1', name: 'echo', arguments: { msg: 'first' } },
+      { id: 'call_2', name: 'echo', arguments: { msg: 'second' } },
+    ],
+    createdAt: now,
+    updatedAt: now,
+  } as unknown as ConversationState<readonly [ReturnType<typeof tool>]>;
+}
+
+function makeStateAccessorAndTool() {
+  const execute = vi.fn(async (params: { msg: string }) => ({ echoed: params.msg }));
+
+  const echoTool = tool({
+    name: 'echo',
+    inputSchema: z.object({ msg: z.string() }),
+    execute,
+  });
+
+  let savedState: ConversationState | null = null;
+  const saveCalls: ConversationState[] = [];
+
+  const state: StateAccessor = {
+    load: vi.fn(async () => makeAwaitingApprovalState()),
+    save: vi.fn(async (s: ConversationState) => {
+      savedState = s;
+      saveCalls.push(JSON.parse(JSON.stringify(s)));
+    }),
+  };
+
+  return { execute, echoTool, state, saveCalls, getSavedState: () => savedState };
+}
+
+function buildModelResult(
+  echoTool: ReturnType<typeof tool>,
+  state: StateAccessor,
+  approveToolCalls: string[],
+  rejectToolCalls: string[],
+) {
+  const options: GetResponseOptions<readonly [ReturnType<typeof tool>]> = {
+    request: { model: 'test-model', input: 'irrelevant for this repro' },
+    client: {} as unknown as OpenRouterCore,
+    tools: [echoTool] as const,
+    state,
+    approveToolCalls,
+    rejectToolCalls,
+  };
+
+  return new ModelResult(options);
+}
+
+describe('Issue #518 - approval decision validation', () => {
+  it('throws when approveToolCalls contains duplicate ids', () => {
+    const { execute, echoTool, state } = makeStateAccessorAndTool();
+
+    expect(() => buildModelResult(echoTool, state, ['call_1', 'call_1'], [])).toThrow(
+      /duplicate id\(s\) in approveToolCalls: call_1/i,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('throws when rejectToolCalls contains duplicate ids', () => {
+    const { execute, echoTool, state } = makeStateAccessorAndTool();
+
+    expect(() => buildModelResult(echoTool, state, [], ['call_1', 'call_1'])).toThrow(
+      /duplicate id\(s\) in rejectToolCalls: call_1/i,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('throws when the same id is present in both approveToolCalls and rejectToolCalls', () => {
+    const { execute, echoTool, state } = makeStateAccessorAndTool();
+
+    expect(() => buildModelResult(echoTool, state, ['call_1'], ['call_1'])).toThrow(
+      /present in both approveToolCalls and rejectToolCalls: call_1/i,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('throws with a combined message for duplicates and intersection', () => {
+    const { execute, echoTool, state } = makeStateAccessorAndTool();
+
+    expect(() =>
+      buildModelResult(echoTool, state, ['call_1', 'call_1'], ['call_1', 'call_2', 'call_2']),
+    ).toThrow(
+      /duplicate id\(s\) in approveToolCalls: call_1.*duplicate id\(s\) in rejectToolCalls: call_2.*present in both approveToolCalls and rejectToolCalls: call_1/is,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('does not throw for empty decision arrays', () => {
+    const { echoTool, state } = makeStateAccessorAndTool();
+    expect(() => buildModelResult(echoTool, state, [], [])).not.toThrow();
+  });
+
+  it('does not throw for unknown call ids (still silently skipped at process time)', () => {
+    const { echoTool, state } = makeStateAccessorAndTool();
+    expect(() => buildModelResult(echoTool, state, ['nope'], [])).not.toThrow();
+  });
+
+  it('happy path: distinct approve id executes exactly once', async () => {
+    const { execute, echoTool, state, saveCalls } = makeStateAccessorAndTool();
+
+    const result = buildModelResult(echoTool, state, ['call_1'], []);
+
+    // getResponse() rejects because call_2 remains pending (no final response).
+    await result.getResponse().catch(() => undefined);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith({ msg: 'first' }, expect.anything());
+
+    const lastSave = saveCalls[saveCalls.length - 1];
+    const call1Results = (lastSave?.unsentToolResults ?? []).filter(
+      (r: { callId: string }) => r.callId === 'call_1',
+    );
+    expect(call1Results).toHaveLength(1);
+    expect(call1Results[0]).toMatchObject({ callId: 'call_1', output: { echoed: 'first' } });
+    expect(call1Results[0]).not.toHaveProperty('error');
+
+    expect(lastSave?.pendingToolCalls).toEqual([
+      { id: 'call_2', name: 'echo', arguments: { msg: 'second' } },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Validates `approveToolCalls` / `rejectToolCalls` at `ModelResult` construction: duplicate ids within either array, or an id present in both, throw a clear `Error` before any tool runs or state mutates.
- Leaves `processApprovalDecisions()` unchanged once decisions are guaranteed distinct and disjoint.
- Adds unit coverage for the throw contract plus a happy-path execute-once case (offline, no API key).

Fixes https://github.com/OpenRouterTeam/typescript-sdk/issues/518

## Why throw (not silent dedup)
Approval is a security boundary. Silent Set-dedup or first-wins would hide caller bugs and, for approve∩reject, could still execute a tool the caller also intended to reject. Correct callers already pass unique disjoint ids and are unaffected.

## Test plan
- [x] `pnpm test -- tests/unit/issue-518-approval-dedup.test.ts` (7 passing)
- [ ] Resume with `approveToolCalls: ['id', 'id']` → sync throw, tool not executed
- [ ] Resume with same id in approve and reject → sync throw
- [ ] Resume with distinct disjoint ids → single execution (unchanged)