### PR TITLE
fix(examples): use exported InputMessageItem type in call-model example

### DIFF
--- a/examples/call-model.example.ts
+++ b/examples/call-model.example.ts
@@ -12,7 +12,7 @@ dotenv.config();
  */
 
 import { OpenRouter } from "../src/index.js";
-import type { OpenResponsesEasyInputMessage } from "../src/models";
+import type { InputMessageItem } from "../src/models";
 
 
 const openRouter = new OpenRouter({
@@ -20,7 +20,7 @@ const openRouter = new OpenRouter({
 });
 
 const text = "Hello! What is your name?";
-const responsesMessages: OpenResponsesEasyInputMessage[] = [
+const responsesMessages: InputMessageItem[] = [
   {
     type: "message",
     role: "user",


### PR DESCRIPTION
## Changes

- Replaced the non-existent `OpenResponsesEasyInputMessage` type with the exported `InputMessageItem` type in `examples/call-model.example.ts`.

## Why

`OpenResponsesEasyInputMessage` is not exported from `src/models/index.ts`, so importing it causes a TypeScript compilation error.

The `callModel()` example accepts a `CallModelInput`, which is based on `ResponsesRequest`. The `input` field in `ResponsesRequest` uses `InputsUnion`, and `InputsUnion` includes `InputMessageItem` as a supported input type.

Using `InputMessageItem` matches the structure already used in the example and aligns it with the SDK's exported types.