### PR TITLE
fix(responses): keep betaResponsesSend as a deprecated standalone function alias

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,4 +1,5 @@
 docs/sdks/alpha
+src/funcs/betaResponsesSend.ts
 .npmignore
 docs/docs.json
 docs/overview.mdx

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.787.0
   generationVersion: 2.914.0
-  releaseVersion: 1.1.2
-  configChecksum: cb2ed8ebe308d3a456cb7b54204b1311
+  releaseVersion: 1.1.3
+  configChecksum: 7bc1af037a5e9064315ce80e4cd589ed
   repoURL: https://github.com/OpenRouterTeam/typescript-sdk.git
   installationURL: https://github.com/OpenRouterTeam/typescript-sdk
   published: true
 persistentEdits:
-  generation_id: dc54e2a9-4ae5-444c-8903-be7c8b481b0b
-  pristine_commit_hash: bc92f53d04e813569ba06216c9e073971ca85d2b
-  pristine_tree_hash: e350de4676e0d601f3a67d679f069dcfdb72f7ed
+  generation_id: 82a9312f-7eaa-4a56-b570-55f2191dbc74
+  pristine_commit_hash: bf574c24427899a03d520eb5a451297254f85831
+  pristine_tree_hash: e7b3b8e2d0e031b34561912022bcc3400f3dabb7
 features:
   typescript:
     acceptHeaders: 2.81.2
@@ -12513,12 +12513,12 @@ trackedFiles:
     pristine_git_object: 410efafd6a7f50d91ccb87131fedbe0c3d47e15a
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:e46a6ad0104da91705e8e95c29464fd6baa9c2a9
-    pristine_git_object: c51ef02db044fbc068b282372f04b55c74637b95
+    last_write_checksum: sha1:1638672bd1f85ec5459837bb5cb65e484bdc9442
+    pristine_git_object: ab7993685206128f0c1c33866638588025909ab7
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:c4ff3e393334ff3f51cbafb01cb320250598864e
-    pristine_git_object: d633de059e5137941a6d2558e1d1d0462089e058
+    last_write_checksum: sha1:a5166259e28d190180a611c1577c33068e4b9b57
+    pristine_git_object: 9bda8dd0383f6c488f92a3bfc048a822ce146464
   src/core.ts:
     id: f431fdbcd144
     last_write_checksum: sha1:5aa66b0b6a5964f3eea7f3098c2eb3c0ee9c0131
@@ -12563,11 +12563,6 @@ trackedFiles:
     id: 979cbc58b672
     last_write_checksum: sha1:a8edf41f3ad50fd4b33ceac7c622bfafc217d048
     pristine_git_object: e318f63fdacd497130db4ca5ab547d14f49cb833
-  src/funcs/betaResponsesSend.ts:
-    id: c5c4ab0c3f76
-    last_write_checksum: sha1:b319452d4053c6d07a46c683c671598d0a93b698
-    pristine_git_object: c466d83b43f6d1d6993e7ef0192bca9ed1a5ee75
-    deleted: true
   src/funcs/byokCreate.ts:
     id: 100cd2d38078
     last_write_checksum: sha1:eac0c86e8979088f900a71c8bc61bbe408a526d7
@@ -12902,8 +12897,8 @@ trackedFiles:
     pristine_git_object: a187e58707bdb726ca2aff74941efe7493422d4e
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:3c37e289d609b328e9b5dd34f413d6e621683e19
-    pristine_git_object: a99a81fd4b03c324277f1514a081f0d5d6cfa19d
+    last_write_checksum: sha1:040b92c7de6985654b088ee167c132e0b1e5ee41
+    pristine_git_object: 2d16721c5320905a235f1d5da0691ea7fd726e6a
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:eaac763b22717206a6199104e0403ed17a4e2711

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.787.0
   generationVersion: 2.914.0
-  releaseVersion: 1.1.4
-  configChecksum: 329f5786b1533a4384fba6dc185be8fa
+  releaseVersion: 1.1.5
+  configChecksum: 003e952347f6705fc5af985644e54c6d
   repoURL: https://github.com/OpenRouterTeam/typescript-sdk.git
   installationURL: https://github.com/OpenRouterTeam/typescript-sdk
   published: true
 persistentEdits:
-  generation_id: 14775019-0cac-4203-9044-f41f5d49dd50
-  pristine_commit_hash: 5a2c0e7697bb78dfa442ec5dc59f253ca6aeb042
-  pristine_tree_hash: 4c03197cc34e3cfae865257cb8e4a91c9aaba5db
+  generation_id: fa876431-29fd-492c-a9c7-48d17b91f3f6
+  pristine_commit_hash: 5945d663d64fdb49d2f59da8db8d9c16317a14d9
+  pristine_tree_hash: d090409e802036f2323f1b32a194472d198d0913
 features:
   typescript:
     acceptHeaders: 2.81.2
@@ -12513,12 +12513,12 @@ trackedFiles:
     pristine_git_object: 410efafd6a7f50d91ccb87131fedbe0c3d47e15a
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:08f39cefb829b5d5a03abb0e301c06456511a78b
-    pristine_git_object: 6f283f8a3bdde67b7beef065258b2277c09513df
+    last_write_checksum: sha1:8cd93270afb050520d63e3adbb81b67a9aa73a98
+    pristine_git_object: a610cefc6b69ad243a7e143a82f879976d9edf9c
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:12ff3273f5ebb282c7309cfd253c2e0a6f1025db
-    pristine_git_object: 51f75781744ada7845247a2d13bbf0ca53cd82dd
+    last_write_checksum: sha1:cb84c1b12a868c561dd6ba4ee9d9e4c76126f99e
+    pristine_git_object: 11d5297b54b0ebc83934e89e9d4b3b56df192ebd
   src/core.ts:
     id: f431fdbcd144
     last_write_checksum: sha1:5aa66b0b6a5964f3eea7f3098c2eb3c0ee9c0131
@@ -12897,8 +12897,8 @@ trackedFiles:
     pristine_git_object: a187e58707bdb726ca2aff74941efe7493422d4e
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:17c1a72ecb451a4b5db9a948e59b1758f62ee697
-    pristine_git_object: 36efdb02f41e4a6cd21fa027fd086b8fbb551af1
+    last_write_checksum: sha1:26d2675453fa28776ddece4f170e9e9097f9f73c
+    pristine_git_object: d06705aeb52eade83adc1f6f8bd6a26854524d63
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:eaac763b22717206a6199104e0403ed17a4e2711

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.787.0
   generationVersion: 2.914.0
-  releaseVersion: 1.1.5
-  configChecksum: 003e952347f6705fc5af985644e54c6d
+  releaseVersion: 1.1.6
+  configChecksum: adb02bd1b1c683964229d525869a515f
   repoURL: https://github.com/OpenRouterTeam/typescript-sdk.git
   installationURL: https://github.com/OpenRouterTeam/typescript-sdk
   published: true
 persistentEdits:
-  generation_id: fa876431-29fd-492c-a9c7-48d17b91f3f6
-  pristine_commit_hash: 5945d663d64fdb49d2f59da8db8d9c16317a14d9
-  pristine_tree_hash: d090409e802036f2323f1b32a194472d198d0913
+  generation_id: 20ca4ac0-fd98-4787-a7ed-a439b5a5e984
+  pristine_commit_hash: 0b625180dd353f716037d444458c56094b88b9c3
+  pristine_tree_hash: 83942e8bfa44b2a65a21b100575bc4fd3ed733ee
 features:
   typescript:
     acceptHeaders: 2.81.2
@@ -12513,12 +12513,12 @@ trackedFiles:
     pristine_git_object: 410efafd6a7f50d91ccb87131fedbe0c3d47e15a
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:8cd93270afb050520d63e3adbb81b67a9aa73a98
-    pristine_git_object: a610cefc6b69ad243a7e143a82f879976d9edf9c
+    last_write_checksum: sha1:f4db08d4b74d25ed8f89b816f0586844e856fd6f
+    pristine_git_object: df292caa91f9a90741d53f577356659292874aff
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:cb84c1b12a868c561dd6ba4ee9d9e4c76126f99e
-    pristine_git_object: 11d5297b54b0ebc83934e89e9d4b3b56df192ebd
+    last_write_checksum: sha1:2a473ebd39cbfe53a120ce1895b0ff70a092001a
+    pristine_git_object: eacb7833103eb2942a1c86a3c9c88fece5c780f8
   src/core.ts:
     id: f431fdbcd144
     last_write_checksum: sha1:5aa66b0b6a5964f3eea7f3098c2eb3c0ee9c0131
@@ -12897,8 +12897,8 @@ trackedFiles:
     pristine_git_object: a187e58707bdb726ca2aff74941efe7493422d4e
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:26d2675453fa28776ddece4f170e9e9097f9f73c
-    pristine_git_object: d06705aeb52eade83adc1f6f8bd6a26854524d63
+    last_write_checksum: sha1:a5975a33c0f0e8c57150b49708524087c5d539b4
+    pristine_git_object: 838ab6de06c192f9287d0062d77e186c5e8d4dd8
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:eaac763b22717206a6199104e0403ed17a4e2711

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.787.0
   generationVersion: 2.914.0
-  releaseVersion: 1.1.3
-  configChecksum: 7bc1af037a5e9064315ce80e4cd589ed
+  releaseVersion: 1.1.4
+  configChecksum: 329f5786b1533a4384fba6dc185be8fa
   repoURL: https://github.com/OpenRouterTeam/typescript-sdk.git
   installationURL: https://github.com/OpenRouterTeam/typescript-sdk
   published: true
 persistentEdits:
-  generation_id: 82a9312f-7eaa-4a56-b570-55f2191dbc74
-  pristine_commit_hash: bf574c24427899a03d520eb5a451297254f85831
-  pristine_tree_hash: e7b3b8e2d0e031b34561912022bcc3400f3dabb7
+  generation_id: 14775019-0cac-4203-9044-f41f5d49dd50
+  pristine_commit_hash: 5a2c0e7697bb78dfa442ec5dc59f253ca6aeb042
+  pristine_tree_hash: 4c03197cc34e3cfae865257cb8e4a91c9aaba5db
 features:
   typescript:
     acceptHeaders: 2.81.2
@@ -12513,12 +12513,12 @@ trackedFiles:
     pristine_git_object: 410efafd6a7f50d91ccb87131fedbe0c3d47e15a
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:1638672bd1f85ec5459837bb5cb65e484bdc9442
-    pristine_git_object: ab7993685206128f0c1c33866638588025909ab7
+    last_write_checksum: sha1:08f39cefb829b5d5a03abb0e301c06456511a78b
+    pristine_git_object: 6f283f8a3bdde67b7beef065258b2277c09513df
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:a5166259e28d190180a611c1577c33068e4b9b57
-    pristine_git_object: 9bda8dd0383f6c488f92a3bfc048a822ce146464
+    last_write_checksum: sha1:12ff3273f5ebb282c7309cfd253c2e0a6f1025db
+    pristine_git_object: 51f75781744ada7845247a2d13bbf0ca53cd82dd
   src/core.ts:
     id: f431fdbcd144
     last_write_checksum: sha1:5aa66b0b6a5964f3eea7f3098c2eb3c0ee9c0131
@@ -12897,8 +12897,8 @@ trackedFiles:
     pristine_git_object: a187e58707bdb726ca2aff74941efe7493422d4e
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:040b92c7de6985654b088ee167c132e0b1e5ee41
-    pristine_git_object: 2d16721c5320905a235f1d5da0691ea7fd726e6a
+    last_write_checksum: sha1:17c1a72ecb451a4b5db9a948e59b1758f62ee697
+    pristine_git_object: 36efdb02f41e4a6cd21fa027fd086b8fbb551af1
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:eaac763b22717206a6199104e0403ed17a4e2711

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -37,7 +37,7 @@ generation:
   documentation: mintlify
   preApplyUnionDiscriminators: true
 typescript:
-  version: 1.1.2
+  version: 1.1.3
   acceptHeaderEnum: false
   additionalDependencies:
     dependencies:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -37,7 +37,7 @@ generation:
   documentation: mintlify
   preApplyUnionDiscriminators: true
 typescript:
-  version: 1.1.3
+  version: 1.1.4
   acceptHeaderEnum: false
   additionalDependencies:
     dependencies:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -37,7 +37,7 @@ generation:
   documentation: mintlify
   preApplyUnionDiscriminators: true
 typescript:
-  version: 1.1.5
+  version: 1.1.6
   acceptHeaderEnum: false
   additionalDependencies:
     dependencies:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -37,7 +37,7 @@ generation:
   documentation: mintlify
   preApplyUnionDiscriminators: true
 typescript:
-  version: 1.1.4
+  version: 1.1.5
   acceptHeaderEnum: false
   additionalDependencies:
     dependencies:

--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -34665,7 +34665,7 @@ paths:
           description: 'Provider Overloaded - Provider is temporarily overloaded'
       summary: 'Create a response'
       tags:
-        - 'beta.responses'
+        - 'responses'
       x-speakeasy-name-override: 'send'
       x-speakeasy-stream-request-field: 'stream'
   /videos:
@@ -35952,8 +35952,8 @@ tags:
     name: 'Workspaces'
   - description: 'beta.Analytics endpoints'
     name: 'beta.Analytics'
-  - description: 'beta.responses endpoints'
-    name: 'beta.responses'
+  - description: 'responses endpoints'
+    name: 'responses'
 x-retry-strategy:
   initialDelay: 500
   maxAttempts: 3

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -6,6 +6,7 @@ sources:
         sourceBlobDigest: sha256:80b81a7f81722d59ebe16f7329b2da855e3fa49ae6cae3fabcc100e88fc2d9a5
         tags:
             - latest
+            - devin-1784943452-beta-responses-func-alias
             - 1.0.0
 targets:
     openrouter:
@@ -14,7 +15,7 @@ targets:
         sourceRevisionDigest: sha256:02968ade60cf270bd823daa61f643a374a1b151824c4627df3281668525a0429
         sourceBlobDigest: sha256:80b81a7f81722d59ebe16f7329b2da855e3fa49ae6cae3fabcc100e88fc2d9a5
         codeSamplesNamespace: open-router-chat-completions-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:bfec561e7f59a6f5ce78e3a415100c603e56be60c59321764f970ae92e3c6a90
+        codeSamplesRevisionDigest: sha256:f55ba2eefdce41ce7571767c0e5bc68dbfab2b6277b7761189c17f6da188a146
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.787.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -15,7 +15,7 @@ targets:
         sourceRevisionDigest: sha256:02968ade60cf270bd823daa61f643a374a1b151824c4627df3281668525a0429
         sourceBlobDigest: sha256:80b81a7f81722d59ebe16f7329b2da855e3fa49ae6cae3fabcc100e88fc2d9a5
         codeSamplesNamespace: open-router-chat-completions-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:f55ba2eefdce41ce7571767c0e5bc68dbfab2b6277b7761189c17f6da188a146
+        codeSamplesRevisionDigest: sha256:9994c15f0c4cea2ad850d220a6db893a1977600ace3b8d45e7e6d04b7b76b616
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.787.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -6,7 +6,6 @@ sources:
         sourceBlobDigest: sha256:80b81a7f81722d59ebe16f7329b2da855e3fa49ae6cae3fabcc100e88fc2d9a5
         tags:
             - latest
-            - devin-1784853533-responses-ga
             - 1.0.0
 targets:
     openrouter:
@@ -15,7 +14,7 @@ targets:
         sourceRevisionDigest: sha256:02968ade60cf270bd823daa61f643a374a1b151824c4627df3281668525a0429
         sourceBlobDigest: sha256:80b81a7f81722d59ebe16f7329b2da855e3fa49ae6cae3fabcc100e88fc2d9a5
         codeSamplesNamespace: open-router-chat-completions-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:49591992753ec5bf41f7ee38722c8034d1c0562d73ca59b531ecce7473513c4e
+        codeSamplesRevisionDigest: sha256:bfec561e7f59a6f5ce78e3a415100c603e56be60c59321764f970ae92e3c6a90
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.787.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -15,7 +15,7 @@ targets:
         sourceRevisionDigest: sha256:02968ade60cf270bd823daa61f643a374a1b151824c4627df3281668525a0429
         sourceBlobDigest: sha256:80b81a7f81722d59ebe16f7329b2da855e3fa49ae6cae3fabcc100e88fc2d9a5
         codeSamplesNamespace: open-router-chat-completions-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:9994c15f0c4cea2ad850d220a6db893a1977600ace3b8d45e7e6d04b7b76b616
+        codeSamplesRevisionDigest: sha256:3117dce9e2716aa4daf40ef0c845b52a38dafb551c0e675f3a523ed64cd709a0
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.787.0

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@openrouter/sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@openrouter/sdk",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@openrouter/sdk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@openrouter/sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "OpenRouter",
   "description": "The OpenRouter TypeScript SDK is a type-safe toolkit for building AI applications with access to 400+ language models through a unified API.",
   "keywords": [
@@ -73,15 +73,15 @@
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "vitest --run --project unit",
-    "typecheck": "tsc --noEmit",
-    "compile": "tsc",
-    "test:e2e": "vitest --run --project e2e",
     "test:transit": "exit 0",
     "test:watch": "vitest --watch --project unit",
+    "prepare": "npm run build",
+    "test": "vitest --run --project unit",
+    "test:e2e": "vitest --run --project e2e",
+    "typecheck": "tsc --noEmit",
     "typecheck:transit": "exit 0",
-    "postinstall": "node scripts/check-types.js || true",
-    "prepare": "npm run build"
+    "compile": "tsc",
+    "postinstall": "node scripts/check-types.js || true"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "OpenRouter",
   "description": "The OpenRouter TypeScript SDK is a type-safe toolkit for building AI applications with access to 400+ language models through a unified API.",
   "keywords": [
@@ -73,15 +73,15 @@
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "postinstall": "node scripts/check-types.js || true",
     "prepare": "npm run build",
-    "test:e2e": "vitest --run --project e2e",
-    "typecheck:transit": "exit 0",
-    "compile": "tsc",
-    "test": "vitest --run --project unit",
     "test:transit": "exit 0",
+    "typecheck": "tsc --noEmit",
+    "compile": "tsc",
+    "postinstall": "node scripts/check-types.js || true",
+    "test": "vitest --run --project unit",
+    "test:e2e": "vitest --run --project e2e",
     "test:watch": "vitest --watch --project unit",
-    "typecheck": "tsc --noEmit"
+    "typecheck:transit": "exit 0"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/sdk",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "OpenRouter",
   "description": "The OpenRouter TypeScript SDK is a type-safe toolkit for building AI applications with access to 400+ language models through a unified API.",
   "keywords": [
@@ -73,15 +73,15 @@
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "prepare": "npm run build",
-    "test:transit": "exit 0",
+    "test": "vitest --run --project unit",
     "typecheck": "tsc --noEmit",
     "compile": "tsc",
-    "postinstall": "node scripts/check-types.js || true",
-    "test": "vitest --run --project unit",
     "test:e2e": "vitest --run --project e2e",
+    "test:transit": "exit 0",
     "test:watch": "vitest --watch --project unit",
-    "typecheck:transit": "exit 0"
+    "typecheck:transit": "exit 0",
+    "postinstall": "node scripts/check-types.js || true",
+    "prepare": "npm run build"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/sdk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "author": "OpenRouter",
   "description": "The OpenRouter TypeScript SDK is a type-safe toolkit for building AI applications with access to 400+ language models through a unified API.",
   "keywords": [
@@ -73,15 +73,15 @@
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tsc",
     "prepublishOnly": "npm run build",
+    "postinstall": "node scripts/check-types.js || true",
+    "test": "vitest --run --project unit",
     "test:transit": "exit 0",
     "test:watch": "vitest --watch --project unit",
-    "prepare": "npm run build",
-    "test": "vitest --run --project unit",
-    "test:e2e": "vitest --run --project e2e",
     "typecheck": "tsc --noEmit",
     "typecheck:transit": "exit 0",
     "compile": "tsc",
-    "postinstall": "node scripts/check-types.js || true"
+    "prepare": "npm run build",
+    "test:e2e": "vitest --run --project e2e"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/src/funcs/betaResponsesSend.ts
+++ b/src/funcs/betaResponsesSend.ts
@@ -1,0 +1,11 @@
+import { responsesSend } from "./responsesSend.js";
+
+/**
+ * Create a response
+ *
+ * @deprecated Renamed to `responsesSend` now that the Responses API is GA. This
+ * alias is kept for the `beta.responses` deprecation window and will be removed
+ * on the sunset date (TBD). Import
+ * `@openrouter/sdk/funcs/responsesSend.js` instead.
+ */
+export const betaResponsesSend = responsesSend;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -75,7 +75,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "1.1.2",
+  sdkVersion: "1.1.3",
   genVersion: "2.914.0",
-  userAgent: "speakeasy-sdk/typescript 1.1.2 2.914.0 1.0.0 @openrouter/sdk",
+  userAgent: "speakeasy-sdk/typescript 1.1.3 2.914.0 1.0.0 @openrouter/sdk",
 } as const;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -75,7 +75,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "1.1.3",
+  sdkVersion: "1.1.4",
   genVersion: "2.914.0",
-  userAgent: "speakeasy-sdk/typescript 1.1.3 2.914.0 1.0.0 @openrouter/sdk",
+  userAgent: "speakeasy-sdk/typescript 1.1.4 2.914.0 1.0.0 @openrouter/sdk",
 } as const;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -75,7 +75,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "1.1.5",
+  sdkVersion: "1.1.6",
   genVersion: "2.914.0",
-  userAgent: "speakeasy-sdk/typescript 1.1.5 2.914.0 1.0.0 @openrouter/sdk",
+  userAgent: "speakeasy-sdk/typescript 1.1.6 2.914.0 1.0.0 @openrouter/sdk",
 } as const;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -75,7 +75,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "1.1.4",
+  sdkVersion: "1.1.5",
   genVersion: "2.914.0",
-  userAgent: "speakeasy-sdk/typescript 1.1.4 2.914.0 1.0.0 @openrouter/sdk",
+  userAgent: "speakeasy-sdk/typescript 1.1.5 2.914.0 1.0.0 @openrouter/sdk",
 } as const;

--- a/tests/unit/sdk-namespaces.test.ts
+++ b/tests/unit/sdk-namespaces.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { betaResponsesSend } from '../../src/funcs/betaResponsesSend.js';
+import { responsesSend } from '../../src/funcs/responsesSend.js';
 import { OpenRouter } from '../../src/sdk/sdk.js';
 
 describe('SDK namespaces', () => {
@@ -12,6 +14,10 @@ describe('SDK namespaces', () => {
   it('keeps beta.responses as a deprecated alias until sunset', () => {
     expect(client.beta.responses).toBeDefined();
     expect(client.beta.responses.send).toBeTypeOf('function');
+  });
+
+  it('keeps the standalone betaResponsesSend function as a deprecated alias', () => {
+    expect(betaResponsesSend).toBe(responsesSend);
   });
 
   it('leaves other beta namespaces intact', () => {


### PR DESCRIPTION
## Summary

The GA rename in #676 kept the *namespace* alias (`client.beta.responses.send()` still works via the overlay) but silently dropped the *standalone function* export: Speakeasy deleted `src/funcs/betaResponsesSend.ts`, and an overlay cannot resurrect a generated file. That export was documented public API, so `1.1.x` is currently a hard break for anyone importing it:

```ts
// documented in the monorepo docs (api_reference/responses); breaks on 1.1.0+
import { betaResponsesSend } from "@openrouter/sdk/funcs/betaResponsesSend.js";
```

Real fallout: `@openrouter/agent` (all versions incl. the latest `0.8.0`) compiles that import into `esm/lib/model-result.js`, so the monorepo's `@openrouter/sdk` 1.0.19 → 1.1.2 bump PR fails its unit suite with `Cannot find module '@openrouter/sdk/funcs/betaResponsesSend'`.

This restores the func-level alias so it sunsets *with* the namespace alias instead of ahead of it:

```ts
// src/funcs/betaResponsesSend.ts  (hand-written, listed in .genignore)
import { responsesSend } from "./responsesSend.js";

/** @deprecated ... removal on the sunset date (TBD) */
export const betaResponsesSend = responsesSend;
```

`.genignore` keeps regeneration from deleting it again. Verified both import shapes resolve against the built package (`./esm/funcs/betaResponsesSend.js` via the `./*` and `./*.js` export patterns), extensionless included — which is the form `@openrouter/agent` uses.

Also in this PR:

- `.speakeasy/in.openapi.yaml` ← the GA spec. `main`'s copy is still beta-tagged (sdk-bot #687 landed before the monorepo GA merge), which makes the overlay add `beta.responses` on top of a spec that already declares it → duplicate tag → `speakeasy run` dies with `linting failed: ... OpenAPI document invalid`. Reproduced locally; this PR unblocks it. Matching monorepo fix: OpenRouterTeam/openrouter-web#30521 (its own `main` artifact got clobbered by a stale regen). The sdk-bot spec PR will be a no-op once both land.
- Version pinned to `1.1.3` via `speakeasy run --set-version` (consistent across `package.json`, `jsr.json`, `gen.lock`, `config.ts`). The reordered `scripts` block in `package.json` is generator churn, not a hand edit.
- `tests/unit/sdk-namespaces.test.ts` asserts `betaResponsesSend === responsesSend` alongside the existing namespace assertions.

Build + 190/190 unit tests pass.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/6522269e125142fdafb9cf2278c36a9c
Requested by: @christineschen