### PR TITLE
test(e2e): expect embeddings API to reject empty string input

### DIFF
--- a/tests/e2e/embeddings.test.ts
+++ b/tests/e2e/embeddings.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'vitest';
+import { BadRequestResponseError } from '../../src/models/errors/badrequestresponseerror.js';
 import { OpenRouter } from '../../src/sdk/sdk.js';
 
 describe('Embeddings E2E Tests', () => {
@@ -116,23 +117,15 @@ describe('Embeddings E2E Tests', () => {
       }
     });
 
-    it('should handle empty string input gracefully', async () => {
-      const response = await client.embeddings.generate({
-        requestBody: {
-          input: '',
-          model: 'openai/text-embedding-3-small',
-        },
-      });
-
-      expect(response).toBeDefined();
-
-      expect(response.data).toBeDefined();
-      expect(Array.isArray(response.data)).toBe(true);
-
-      if (response.data.length > 0) {
-        const embedding = response.data[0];
-        expect(embedding?.embedding).toBeDefined();
-      }
+    it('should reject an empty string input', async () => {
+      await expect(
+        client.embeddings.generate({
+          requestBody: {
+            input: '',
+            model: 'openai/text-embedding-3-small',
+          },
+        }),
+      ).rejects.toThrow(BadRequestResponseError);
     });
 
     it('should include model information in response', async () => {


### PR DESCRIPTION
## Summary

`validate` has been red on every PR (mine, and Speakeasy's autogen branches) since openrouter-web#30855 — "fix(embeddings): validate non-empty input…" — tightened the embeddings request schema on Jul 27:

```diff
# packages/embedding-interfaces/schemas/request/index.ts
-  input: z.union([z.string(), z.array(z.string()), ...])
+  input: z.union([z.string().min(1), z.array(z.string().min(1)), ...])
```

Prod now answers `input: ''` with `400 too_small: expected string to have >=1 characters`, so the e2e test that asserted empty input *succeeds* throws instead. This flips the test to assert the new (intended) contract:

```diff
-it('should handle empty string input gracefully', async () => {
-  const response = await client.embeddings.generate({ requestBody: { input: '', ... } });
-  expect(response.data).toBeDefined();
+it('should reject an empty string input', async () => {
+  await expect(client.embeddings.generate({ requestBody: { input: '', ... } }))
+    .rejects.toThrow(BadRequestResponseError);
 });
```

No SDK/source change — `tests/e2e/embeddings.test.ts` only. Verified against the live API: `vitest run tests/e2e/embeddings.test.ts` → 5/5 pass (was 4/5).


Link to Devin session: https://openrouter.devinenterprise.com/sessions/236b5466ec42476c8645101ef5bcd17f
Requested by: @christineschen