### PR TITLE
perf: amortize replay buffer compaction in ToolEventBroadcaster and ReusableReadableStream

### DIFF
--- a/src/funcs/call-model.ts
+++ b/src/funcs/call-model.ts
@@ -87,6 +87,7 @@ export function callModel<
     sharedContextSchema,
     onTurnStart,
     onTurnEnd,
+    streamReplay,
     ...apiRequest
   } = request;
 
@@ -128,5 +129,6 @@ export function callModel<
     ...(sharedContextSchema !== undefined && { sharedContextSchema }),
     ...(onTurnStart !== undefined && { onTurnStart }),
     ...(onTurnEnd !== undefined && { onTurnEnd }),
+    ...(streamReplay !== undefined && { streamReplay }),
   } as GetResponseOptions<TTools, TShared>);
 }

--- a/src/lib/async-params.ts
+++ b/src/lib/async-params.ts
@@ -2,6 +2,7 @@ import type * as models from '../models/index.js';
 import type { ToolContextMapWithShared, ParsedToolCall, StateAccessor, StopWhen, Tool, TurnContext } from './tool-types.js';
 import type { OpenResponsesResult } from '../models/index.js';
 import type { ContextInput } from './tool-context.js';
+import type { StreamReplay } from './reusable-stream.js';
 
 // Re-export Tool type for convenience
 export type { Tool } from './tool-types.js';
@@ -66,6 +67,13 @@ type BaseCallModelInput<
    * Receives the turn context and the completed response for that turn
    */
   onTurnEnd?: (context: TurnContext, response: OpenResponsesResult) => void | Promise<void>;
+  /**
+   * Controls replay history retained for stream getters.
+   * `full` preserves all events for delayed and sequential consumers.
+   * `active-consumers` compacts events after every attached consumer advances.
+   * @default 'full'
+   */
+  streamReplay?: StreamReplay;
 };
 
 /**
@@ -162,6 +170,7 @@ export async function resolveAsyncFunctions<TTools extends readonly Tool[] = rea
     'sharedContextSchema',   // Client-side schema for shared context validation
     'onTurnStart',           // Client-side turn start callback
     'onTurnEnd',             // Client-side turn end callback
+    'streamReplay',          // Client-side stream replay policy
   ]);
 
   // Iterate over all keys in the input

--- a/src/lib/model-result.ts
+++ b/src/lib/model-result.ts
@@ -197,6 +197,8 @@ export class ModelResult<
   > | null = null;
   private initialStreamPipeStarted = false;
   private initialPipePromise: Promise<void> | null = null;
+  private initialResponse: models.OpenResponsesResult | null = null;
+  private initialResponseError: Error | null = null;
 
   // Context store for typed tool context (persists across turns)
   private contextStore: ToolContextStore | null = null;
@@ -271,8 +273,34 @@ export class ModelResult<
         timestamp: Date.now(),
       } satisfies TurnEndEvent);
     })().catch((error) => {
-      broadcaster.complete(error instanceof Error ? error : new Error(String(error)));
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      this.initialResponseError = normalizedError;
+      broadcaster.complete(normalizedError);
     });
+  }
+
+  /** Cache the terminal response so aggregate readers do not need trimmed history. */
+  private captureInitialStreamEvent(event: models.StreamEvents): void {
+    if (isResponseCompletedEvent(event) || isResponseIncompleteEvent(event)) {
+      this.initialResponse = event.response;
+      return;
+    }
+
+    if (isResponseFailedEvent(event)) {
+      this.initialResponseError = new Error(
+        `Response failed: ${JSON.stringify(event.response.error)}`,
+      );
+    }
+  }
+
+  /** Replace the initial stream and reset its terminal snapshot. */
+  private setReusableStream(stream: ReadableStream<models.StreamEvents>): void {
+    this.initialResponse = null;
+    this.initialResponseError = null;
+    this.reusableStream = new ReusableReadableStream(
+      stream,
+      (event) => this.captureInitialStreamEvent(event),
+    );
   }
 
   /**
@@ -420,6 +448,24 @@ export class ModelResult<
     if (this.finalResponse) {
       return this.finalResponse;
     }
+
+    const initialPipePromise = this.initialPipePromise;
+    if (initialPipePromise) {
+      await initialPipePromise;
+    }
+
+    if (this.initialResponseError) {
+      throw this.initialResponseError;
+    }
+
+    if (this.initialResponse) {
+      return this.initialResponse;
+    }
+
+    if (initialPipePromise) {
+      throw new Error('Stream ended without completion event');
+    }
+
     if (this.reusableStream) {
       return consumeStreamForCompletion(this.reusableStream);
     }
@@ -1080,7 +1126,7 @@ export class ModelResult<
       // Handle both streaming and non-streaming responses
       // The API may return a non-streaming response even when stream: true is requested
       if (isEventStream(apiResult.value)) {
-        this.reusableStream = new ReusableReadableStream(apiResult.value);
+        this.setReusableStream(apiResult.value);
       } else if (this.isNonStreamingResponse(apiResult.value)) {
         // API returned a complete response directly - use it as the final response
         this.finalResponse = apiResult.value;
@@ -1225,7 +1271,7 @@ export class ModelResult<
 
     // Handle both streaming and non-streaming responses
     if (isEventStream(apiResult.value)) {
-      this.reusableStream = new ReusableReadableStream(apiResult.value);
+      this.setReusableStream(apiResult.value);
     } else if (this.isNonStreamingResponse(apiResult.value)) {
       this.finalResponse = apiResult.value;
     } else {
@@ -1679,7 +1725,7 @@ export class ModelResult<
       throw new Error('Stream not initialized');
     }
 
-    const completedResponse = await consumeStreamForCompletion(this.reusableStream);
+    const completedResponse = await this.getInitialResponse();
     return extractToolCallsFromResponse(completedResponse) as ParsedToolCall<TTools[number]>[];
   }
 

--- a/src/lib/model-result.ts
+++ b/src/lib/model-result.ts
@@ -40,7 +40,10 @@ import {
   unsentResultsToAPIFormat,
   updateState,
 } from './conversation-state.js';
-import { ReusableReadableStream } from './reusable-stream.js';
+import {
+  ReusableReadableStream,
+  type StreamReplay,
+} from './reusable-stream.js';
 import {
   buildItemsStream,
   buildResponsesMessageStream,
@@ -97,6 +100,14 @@ function isEventStream(value: unknown): value is EventStream<models.StreamEvents
   return typeof maybeStream.toReadableStream === 'function';
 }
 
+function isTerminalResponseStreamEvent(event: models.StreamEvents): boolean {
+  return (
+    isResponseCompletedEvent(event) ||
+    isResponseFailedEvent(event) ||
+    isResponseIncompleteEvent(event)
+  );
+}
+
 export interface GetResponseOptions<
   TTools extends readonly Tool[],
   TShared extends Record<string, unknown> = Record<string, never>,
@@ -129,6 +140,8 @@ export interface GetResponseOptions<
   onTurnStart?: (context: TurnContext) => void | Promise<void>;
   /** Callback invoked at the end of each tool execution turn */
   onTurnEnd?: (context: TurnContext, response: models.OpenResponsesResult) => void | Promise<void>;
+  /** Replay history retained for delayed and sequential stream consumers. */
+  streamReplay?: StreamReplay;
 }
 
 /**
@@ -199,12 +212,14 @@ export class ModelResult<
   private initialPipePromise: Promise<void> | null = null;
   private initialResponse: models.OpenResponsesResult | null = null;
   private initialResponseError: Error | null = null;
+  private readonly streamReplay: StreamReplay;
 
   // Context store for typed tool context (persists across turns)
   private contextStore: ToolContextStore | null = null;
 
   constructor(options: GetResponseOptions<TTools, TShared>) {
     this.options = options;
+    this.streamReplay = options.streamReplay ?? 'full';
 
     // Runtime validation: approval decisions require state
     const hasApprovalDecisions =
@@ -233,7 +248,7 @@ export class ModelResult<
     ResponseStreamEvent<InferToolEventsUnion<TTools>, InferToolOutputsUnion<TTools>>
   > {
     if (!this.turnBroadcaster) {
-      this.turnBroadcaster = new ToolEventBroadcaster();
+      this.turnBroadcaster = new ToolEventBroadcaster(this.streamReplay);
     }
     return this.turnBroadcaster;
   }
@@ -299,7 +314,11 @@ export class ModelResult<
     this.initialResponseError = null;
     this.reusableStream = new ReusableReadableStream(
       stream,
-      (event) => this.captureInitialStreamEvent(event),
+      {
+        streamReplay: this.streamReplay,
+        onValue: (event) => this.captureInitialStreamEvent(event),
+        isTerminalValue: isTerminalResponseStreamEvent,
+      },
     );
   }
 
@@ -934,7 +953,10 @@ export class ModelResult<
     // Handle streaming or non-streaming response
     const value = newResult.value;
     if (isEventStream(value)) {
-      const followUpStream = new ReusableReadableStream(value);
+      const followUpStream = new ReusableReadableStream(value, {
+        streamReplay: this.streamReplay,
+        isTerminalValue: isTerminalResponseStreamEvent,
+      });
 
       if (this.turnBroadcaster) {
         return this.pipeAndConsumeStream(followUpStream, turnNumber);
@@ -978,7 +1000,7 @@ export class ModelResult<
     }
     // Already resolved, extract non-function fields
     // Filter out stopWhen and state-related fields that aren't part of the API request
-    const { stopWhen: _, state: _s, requireApproval: _r, approveToolCalls: _a, rejectToolCalls: _rj, context: _c, ...rest } = this.options.request;
+    const { stopWhen: _, state: _s, requireApproval: _r, approveToolCalls: _a, rejectToolCalls: _rj, context: _c, streamReplay: _sr, ...rest } = this.options.request;
     return rest as ResolvedCallModelInput;
   }
 

--- a/src/lib/reusable-stream.ts
+++ b/src/lib/reusable-stream.ts
@@ -9,7 +9,10 @@
  * - Each consumer can read at their own pace
  */
 export class ReusableReadableStream<T> {
-  private buffer: T[] = [];
+  private buffer: (T | undefined)[] = [];
+  private bufferHead = 0;
+  // Consumer positions are absolute. Buffer index = bufferHead + position - trimOffset.
+  private trimOffset = 0;
   private consumers = new Map<number, ConsumerState>();
   private nextConsumerId = 0;
   private sourceReader: ReadableStreamDefaultReader<T> | null = null;
@@ -21,12 +24,14 @@ export class ReusableReadableStream<T> {
 
   /**
    * Create a new consumer that can independently iterate over the stream.
-   * Multiple consumers can be created and will all receive the same data.
+   * Consumers receive events from the earliest still-buffered position:
+   * position 0 until a first consumer exists, thereafter the trim watermark.
+   * Multiple consumers can be created and will receive the same remaining data.
    */
   createConsumer(): AsyncIterableIterator<T> {
     const consumerId = this.nextConsumerId++;
     const state: ConsumerState = {
-      position: 0,
+      position: this.trimOffset,
       waitingPromise: null,
       cancelled: false,
     };
@@ -58,10 +63,12 @@ export class ReusableReadableStream<T> {
         }
 
         // If we have buffered data at this position, return it
-        if (consumer.position < self.buffer.length) {
-          const value = self.buffer[consumer.position]!;
+        const bufferIndex =
+          self.bufferHead + consumer.position - self.trimOffset;
+        if (bufferIndex < self.buffer.length) {
+          const value = self.buffer[bufferIndex]!;
           consumer.position++;
-          // Note: We don't clean up buffer to allow sequential/reusable access
+          self.trimConsumed();
           return {
             done: false,
             value,
@@ -94,7 +101,12 @@ export class ReusableReadableStream<T> {
           // Immediately check if we should resolve after setting up the promise
           // This handles the case where data arrived or source completed
           // between our initial checks and promise creation
-          if (self.sourceComplete || self.sourceError || consumer.position < self.buffer.length) {
+          if (
+            self.sourceComplete ||
+            self.sourceError ||
+            self.bufferHead + consumer.position - self.trimOffset <
+              self.buffer.length
+          ) {
             resolve();
           }
         });
@@ -113,6 +125,7 @@ export class ReusableReadableStream<T> {
         if (consumer) {
           consumer.cancelled = true;
           self.consumers.delete(consumerId);
+          self.trimConsumed();
         }
         return {
           done: true,
@@ -125,6 +138,7 @@ export class ReusableReadableStream<T> {
         if (consumer) {
           consumer.cancelled = true;
           self.consumers.delete(consumerId);
+          self.trimConsumed();
         }
         throw e;
       },
@@ -133,6 +147,51 @@ export class ReusableReadableStream<T> {
         return this;
       },
     };
+  }
+
+  /**
+   * Drop buffered chunks every registered consumer has already consumed.
+   * Clear slots immediately so payloads are collectable, but physically
+   * slice only at 1,024 dead slots and 50% waste to amortize compaction.
+   */
+  private trimConsumed(): void {
+    if (this.consumers.size === 0) {
+      return;
+    }
+
+    let min = Infinity;
+    for (const consumer of this.consumers.values()) {
+      if (consumer.position < min) {
+        min = consumer.position;
+      }
+    }
+
+    const nextHead = this.bufferHead + min - this.trimOffset;
+    if (nextHead <= this.bufferHead) {
+      return;
+    }
+
+    this.trimOffset = min;
+    if (nextHead === this.buffer.length) {
+      if (nextHead >= BUFFER_COMPACTION_MIN_HEAD) {
+        this.buffer = [];
+      } else {
+        this.buffer.length = 0;
+      }
+      this.bufferHead = 0;
+      return;
+    }
+
+    this.buffer.fill(undefined, this.bufferHead, nextHead);
+    if (
+      nextHead >= BUFFER_COMPACTION_MIN_HEAD &&
+      nextHead * 2 >= this.buffer.length
+    ) {
+      this.buffer = this.buffer.slice(nextHead);
+      this.bufferHead = 0;
+      return;
+    }
+    this.bufferHead = nextHead;
   }
 
   /**
@@ -218,3 +277,5 @@ interface ConsumerState {
   } | null;
   cancelled: boolean;
 }
+
+const BUFFER_COMPACTION_MIN_HEAD = 1024;

--- a/src/lib/reusable-stream.ts
+++ b/src/lib/reusable-stream.ts
@@ -5,9 +5,18 @@
  * Key features:
  * - Multiple concurrent consumers with independent read positions
  * - New consumers can attach while streaming is active
- * - Efficient memory management with automatic cleanup
+ * - Full replay for delayed and sequential consumers by default
+ * - Opt-in active-consumer replay compaction for bounded memory
  * - Each consumer can read at their own pace
  */
+export type StreamReplay = 'full' | 'active-consumers';
+
+export interface ReusableReadableStreamOptions<T> {
+  streamReplay?: StreamReplay;
+  onValue?: (value: T) => void;
+  isTerminalValue?: (value: T) => boolean;
+}
+
 export class ReusableReadableStream<T> {
   private buffer: (T | undefined)[] = [];
   private bufferHead = 0;
@@ -19,17 +28,25 @@ export class ReusableReadableStream<T> {
   private sourceComplete = false;
   private sourceError: Error | null = null;
   private pumpStarted = false;
+  private sourceCancelPromise: Promise<void> | null = null;
+  private readonly streamReplay: StreamReplay;
+  private readonly onValue: ((value: T) => void) | undefined;
+  private readonly isTerminalValue: ((value: T) => boolean) | undefined;
 
   constructor(
     private sourceStream: ReadableStream<T>,
-    private readonly onValue?: (value: T) => void,
-  ) {}
+    options: ReusableReadableStreamOptions<T> = {},
+  ) {
+    this.streamReplay = options.streamReplay ?? 'full';
+    this.onValue = options.onValue;
+    this.isTerminalValue = options.isTerminalValue;
+  }
 
   /**
    * Create a new consumer that can independently iterate over the stream.
-   * Consumers receive events from the earliest still-buffered position:
-   * position 0 until a first consumer exists, thereafter the trim watermark.
-   * Multiple consumers can be created and will receive the same remaining data.
+   * Full-replay consumers start at position 0. Active-consumer replay starts
+   * at the current trim watermark. Multiple attached consumers advance
+   * independently in either mode.
    */
   createConsumer(): AsyncIterableIterator<T> {
     const consumerId = this.nextConsumerId++;
@@ -156,9 +173,10 @@ export class ReusableReadableStream<T> {
    * Drop buffered chunks every registered consumer has already consumed.
    * Clear slots immediately so payloads are collectable, but physically
    * slice only at 1,024 dead slots and 50% waste to amortize compaction.
+   * This is enabled only for active-consumer replay.
    */
   private trimConsumed(): void {
-    if (this.consumers.size === 0) {
+    if (this.streamReplay === 'full' || this.consumers.size === 0) {
       return;
     }
 
@@ -207,10 +225,11 @@ export class ReusableReadableStream<T> {
     this.pumpStarted = true;
     this.sourceReader = this.sourceStream.getReader();
 
+    const sourceReader = this.sourceReader;
     void (async () => {
       try {
         while (true) {
-          const result = await this.sourceReader!.read();
+          const result = await sourceReader.read();
 
           if (result.done) {
             this.sourceComplete = true;
@@ -224,16 +243,38 @@ export class ReusableReadableStream<T> {
 
           // Notify waiting consumers
           this.notifyAllConsumers();
+
+          if (this.isTerminalValue?.(result.value)) {
+            this.sourceComplete = true;
+            this.notifyAllConsumers();
+            try {
+              await this.cancelSourceReader(sourceReader);
+            } catch {
+              // The terminal event is authoritative; cancellation is cleanup only.
+            }
+            break;
+          }
         }
       } catch (error) {
         this.sourceError = error instanceof Error ? error : new Error(String(error));
         this.notifyAllConsumers();
       } finally {
-        if (this.sourceReader) {
-          this.sourceReader.releaseLock();
+        sourceReader.releaseLock();
+        if (this.sourceReader === sourceReader) {
+          this.sourceReader = null;
         }
       }
     })();
+  }
+
+  /** Cancel the source reader at most once across terminal and public cancellation. */
+  private cancelSourceReader(
+    sourceReader: ReadableStreamDefaultReader<T>,
+  ): Promise<void> {
+    if (!this.sourceCancelPromise) {
+      this.sourceCancelPromise = sourceReader.cancel();
+    }
+    return this.sourceCancelPromise;
   }
 
   /**
@@ -267,8 +308,7 @@ export class ReusableReadableStream<T> {
 
     // Cancel the source stream
     if (this.sourceReader) {
-      await this.sourceReader.cancel();
-      this.sourceReader.releaseLock();
+      await this.cancelSourceReader(this.sourceReader);
     }
   }
 }

--- a/src/lib/reusable-stream.ts
+++ b/src/lib/reusable-stream.ts
@@ -20,7 +20,10 @@ export class ReusableReadableStream<T> {
   private sourceError: Error | null = null;
   private pumpStarted = false;
 
-  constructor(private sourceStream: ReadableStream<T>) {}
+  constructor(
+    private sourceStream: ReadableStream<T>,
+    private readonly onValue?: (value: T) => void,
+  ) {}
 
   /**
    * Create a new consumer that can independently iterate over the stream.
@@ -217,6 +220,7 @@ export class ReusableReadableStream<T> {
 
           // Add to buffer
           this.buffer.push(result.value);
+          this.onValue?.(result.value);
 
           // Notify waiting consumers
           this.notifyAllConsumers();

--- a/src/lib/tool-event-broadcaster.ts
+++ b/src/lib/tool-event-broadcaster.ts
@@ -1,10 +1,13 @@
+import type { StreamReplay } from './reusable-stream.js';
+
 /**
  * A push-based event broadcaster that supports multiple concurrent consumers.
  * Similar to ReusableReadableStream but for push-based events from tool execution.
  *
- * Each consumer gets their own position in the buffer and receives all events
- * from the earliest still-buffered position. This enables real-time streaming
- * of generator tool preliminary results to multiple consumers simultaneously.
+ * Each consumer gets their own position in the buffer. Full replay is the
+ * default; callers can opt into watermark compaction for active consumers.
+ * This enables real-time streaming of generator tool preliminary results to
+ * multiple consumers simultaneously.
  *
  * @template T - The event type being broadcast
  */
@@ -18,10 +21,12 @@ export class ToolEventBroadcaster<T> {
   private isComplete = false;
   private completionError: Error | null = null;
 
+  constructor(private readonly streamReplay: StreamReplay = 'full') {}
+
   /**
    * Push a new event to all consumers.
-   * Events are buffered so late-joining consumers can catch up from the trim
-   * watermark.
+   * Events are buffered so late-joining consumers can catch up according to
+   * the configured replay policy.
    */
   push(event: T): void {
     if (this.isComplete) {
@@ -50,7 +55,11 @@ export class ToolEventBroadcaster<T> {
    */
   private cleanup(): void {
     // Only cleanup if complete and all consumers are done
-    if (this.isComplete && this.consumers.size === 0) {
+    if (
+      this.streamReplay === 'active-consumers' &&
+      this.isComplete &&
+      this.consumers.size === 0
+    ) {
       this.buffer = [];
       this.bufferHead = 0;
     }
@@ -58,9 +67,9 @@ export class ToolEventBroadcaster<T> {
 
   /**
    * Create a new consumer that can independently iterate over events.
-   * Consumers receive events from the earliest still-buffered position:
-   * position 0 until a first consumer exists, thereafter the trim watermark.
-   * Multiple consumers can be created and will all receive the same events.
+   * Full-replay consumers start at position 0. Active-consumer replay starts
+   * at the current trim watermark. Multiple attached consumers advance
+   * independently in either mode.
    */
   createConsumer(): AsyncIterableIterator<T> {
     const consumerId = this.nextConsumerId++;
@@ -159,9 +168,10 @@ export class ToolEventBroadcaster<T> {
    * Drop buffered events every registered consumer has already consumed.
    * Clear slots immediately so payloads are collectable, but physically
    * slice only at 1,024 dead slots and 50% waste to amortize compaction.
+   * This is enabled only for active-consumer replay.
    */
   private trimConsumed(): void {
-    if (this.consumers.size === 0) {
+    if (this.streamReplay === 'full' || this.consumers.size === 0) {
       return;
     }
 

--- a/src/lib/tool-event-broadcaster.ts
+++ b/src/lib/tool-event-broadcaster.ts
@@ -3,13 +3,16 @@
  * Similar to ReusableReadableStream but for push-based events from tool execution.
  *
  * Each consumer gets their own position in the buffer and receives all events
- * from their join point onward. This enables real-time streaming of generator
- * tool preliminary results to multiple consumers simultaneously.
+ * from the earliest still-buffered position. This enables real-time streaming
+ * of generator tool preliminary results to multiple consumers simultaneously.
  *
  * @template T - The event type being broadcast
  */
 export class ToolEventBroadcaster<T> {
-  private buffer: T[] = [];
+  private buffer: (T | undefined)[] = [];
+  private bufferHead = 0;
+  // Consumer positions are absolute. Buffer index = bufferHead + position - trimOffset.
+  private trimOffset = 0;
   private consumers = new Map<number, ConsumerState>();
   private nextConsumerId = 0;
   private isComplete = false;
@@ -17,7 +20,8 @@ export class ToolEventBroadcaster<T> {
 
   /**
    * Push a new event to all consumers.
-   * Events are buffered so late-joining consumers can catch up.
+   * Events are buffered so late-joining consumers can catch up from the trim
+   * watermark.
    */
   push(event: T): void {
     if (this.isComplete) {
@@ -48,18 +52,20 @@ export class ToolEventBroadcaster<T> {
     // Only cleanup if complete and all consumers are done
     if (this.isComplete && this.consumers.size === 0) {
       this.buffer = [];
+      this.bufferHead = 0;
     }
   }
 
   /**
    * Create a new consumer that can independently iterate over events.
-   * Consumers can join at any time and will receive events from position 0.
+   * Consumers receive events from the earliest still-buffered position:
+   * position 0 until a first consumer exists, thereafter the trim watermark.
    * Multiple consumers can be created and will all receive the same events.
    */
   createConsumer(): AsyncIterableIterator<T> {
     const consumerId = this.nextConsumerId++;
     const state: ConsumerState = {
-      position: 0,
+      position: this.trimOffset,
       waitingPromise: null,
       cancelled: false,
     };
@@ -80,9 +86,12 @@ export class ToolEventBroadcaster<T> {
         }
 
         // Return buffered event if available
-        if (consumer.position < self.buffer.length) {
-          const value = self.buffer[consumer.position]!;
+        const bufferIndex =
+          self.bufferHead + consumer.position - self.trimOffset;
+        if (bufferIndex < self.buffer.length) {
+          const value = self.buffer[bufferIndex]!;
           consumer.position++;
+          self.trimConsumed();
           return { done: false, value };
         }
 
@@ -104,7 +113,8 @@ export class ToolEventBroadcaster<T> {
           if (
             self.isComplete ||
             self.completionError ||
-            consumer.position < self.buffer.length
+            self.bufferHead + consumer.position - self.trimOffset <
+              self.buffer.length
           ) {
             resolve();
           }
@@ -122,6 +132,7 @@ export class ToolEventBroadcaster<T> {
         if (consumer) {
           consumer.cancelled = true;
           self.consumers.delete(consumerId);
+          self.trimConsumed();
           self.cleanup();
         }
         return { done: true, value: undefined };
@@ -132,6 +143,7 @@ export class ToolEventBroadcaster<T> {
         if (consumer) {
           consumer.cancelled = true;
           self.consumers.delete(consumerId);
+          self.trimConsumed();
           self.cleanup();
         }
         throw e;
@@ -141,6 +153,51 @@ export class ToolEventBroadcaster<T> {
         return this;
       },
     };
+  }
+
+  /**
+   * Drop buffered events every registered consumer has already consumed.
+   * Clear slots immediately so payloads are collectable, but physically
+   * slice only at 1,024 dead slots and 50% waste to amortize compaction.
+   */
+  private trimConsumed(): void {
+    if (this.consumers.size === 0) {
+      return;
+    }
+
+    let min = Infinity;
+    for (const consumer of this.consumers.values()) {
+      if (consumer.position < min) {
+        min = consumer.position;
+      }
+    }
+
+    const nextHead = this.bufferHead + min - this.trimOffset;
+    if (nextHead <= this.bufferHead) {
+      return;
+    }
+
+    this.trimOffset = min;
+    if (nextHead === this.buffer.length) {
+      if (nextHead >= BUFFER_COMPACTION_MIN_HEAD) {
+        this.buffer = [];
+      } else {
+        this.buffer.length = 0;
+      }
+      this.bufferHead = 0;
+      return;
+    }
+
+    this.buffer.fill(undefined, this.bufferHead, nextHead);
+    if (
+      nextHead >= BUFFER_COMPACTION_MIN_HEAD &&
+      nextHead * 2 >= this.buffer.length
+    ) {
+      this.buffer = this.buffer.slice(nextHead);
+      this.bufferHead = 0;
+      return;
+    }
+    this.bufferHead = nextHead;
   }
 
   /**
@@ -168,3 +225,5 @@ interface ConsumerState {
   } | null;
   cancelled: boolean;
 }
+
+const BUFFER_COMPACTION_MIN_HEAD = 1024;

--- a/tests/unit/model-result-replay-compaction.test.ts
+++ b/tests/unit/model-result-replay-compaction.test.ts
@@ -68,8 +68,23 @@ const TOOL_CALL = {
   status: 'completed',
 } as const;
 
+const WEATHER_TOOL = tool({
+  name: 'weather',
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  outputSchema: z.object({
+    temperature: z.number(),
+  }),
+  async execute(): Promise<{ temperature: number }> {
+    return {
+      temperature: 72,
+    };
+  },
+});
+
 describe('ModelResult replay-buffer compaction', () => {
-  it('returns the final response after getTextStream drains trimmed events', async () => {
+  it('replays initial events to sequential stream getters by default', async () => {
     const { client } = clientWithResponses([
       completedSseResponse('resp_text', [FINAL_MESSAGE], [textDeltaEvent('hello')]),
     ]);
@@ -80,18 +95,39 @@ describe('ModelResult replay-buffer compaction', () => {
 
     expect(await Array.fromAsync(result.getTextStream())).toEqual(['hello']);
 
+    const replayedEvents = await Array.fromAsync(result.getFullResponsesStream());
+    expect(replayedEvents.map((event) => event.type)).toEqual([
+      'response.created',
+      'response.output_text.delta',
+      'response.completed',
+    ]);
+  });
+
+  it('returns the final response after active-consumer replay trims streamed events', async () => {
+    const { client } = clientWithResponses([
+      completedSseResponse('resp_text', [FINAL_MESSAGE], [textDeltaEvent('hello')]),
+    ]);
+    const result = callModel(client, {
+      model: 'test/model',
+      input: 'Say hello',
+      streamReplay: 'active-consumers',
+    });
+
+    expect(await Array.fromAsync(result.getTextStream())).toEqual(['hello']);
+
     const response = await result.getResponse();
     expect(response.id).toBe('resp_text');
     expect(await result.getText()).toBe('hello');
   });
 
-  it('returns tool calls after getFullResponsesStream drains trimmed events', async () => {
+  it('returns tool calls after active-consumer replay trims streamed events', async () => {
     const { client } = clientWithResponses([
       completedSseResponse('resp_tool_call', [TOOL_CALL]),
     ]);
     const result = callModel(client, {
       model: 'test/model',
       input: 'Check the weather',
+      streamReplay: 'active-consumers',
     });
 
     await Array.fromAsync(result.getFullResponsesStream());
@@ -114,6 +150,7 @@ describe('ModelResult replay-buffer compaction', () => {
     const result = callModel(client, {
       model: 'test/model',
       input: 'Fail this request',
+      streamReplay: 'active-consumers',
     });
 
     await Array.fromAsync(result.getFullResponsesStream());
@@ -121,33 +158,80 @@ describe('ModelResult replay-buffer compaction', () => {
     await expect(result.getResponse()).rejects.toThrow('upstream provider failed');
   });
 
-  it('coordinates the initial pipe with an immediate streaming tool response', async () => {
-    const panelTool = tool({
-      name: 'weather',
-      inputSchema: z.object({
-        city: z.string(),
-      }),
-      outputSchema: z.object({
-        temperature: z.number(),
-      }),
-      async execute(): Promise<{ temperature: number }> {
-        return {
-          temperature: 72,
-        };
-      },
-    });
-    const { client, requestCount } = clientWithResponses([
-      completedSseResponse(
-        'resp_tool_call',
-        [TOOL_CALL],
-        Array.from({ length: 256 }, (_, index) => textDeltaEvent('x', index + 1)),
-      ),
+  it('keeps streamReplay out of initial and reconstructed follow-up request bodies', async () => {
+    const { client, requestBodies } = clientWithResponses([
+      completedSseResponse('resp_tool_call', [TOOL_CALL]),
       completedSseResponse('resp_final', [FINAL_MESSAGE]),
     ]);
     const result = callModel(client, {
       model: 'test/model',
       input: 'Check the weather',
-      tools: [panelTool],
+      tools: [WEATHER_TOOL],
+      streamReplay: 'active-consumers',
+    });
+
+    expect((await result.getResponse()).id).toBe('resp_final');
+    expect(requestBodies()).toHaveLength(2);
+    expect(requestBodies().every((body) => !('streamReplay' in body))).toBe(true);
+  });
+
+  it.each(['response.completed', 'response.incomplete'] as const)(
+    'settles an open body at %s and cancels the source exactly once',
+    async (terminalType) => {
+      const terminal = openTerminalSseResponse(
+        `resp_${terminalType}`,
+        terminalType,
+        [FINAL_MESSAGE],
+        terminalType === 'response.completed',
+      );
+      const { client } = clientWithResponses([terminal.response]);
+      const result = callModel(client, {
+        model: 'test/model',
+        input: 'Say hello',
+      });
+
+      const response = await result.getResponse();
+
+      expect(response.id).toBe(`resp_${terminalType}`);
+      expect(terminal.cancellationCount()).toBe(1);
+    },
+  );
+
+  it('settles an open failed body with the provider error and cancels exactly once', async () => {
+    const terminal = openTerminalSseResponse(
+      'resp_failed_open',
+      'response.failed',
+      [],
+    );
+    const { client } = clientWithResponses([terminal.response]);
+    const result = callModel(client, {
+      model: 'test/model',
+      input: 'Fail this request',
+    });
+
+    await expect(result.getResponse()).rejects.toThrow('upstream provider failed');
+    expect(terminal.cancellationCount()).toBe(1);
+  });
+
+  it('cancels open initial and follow-up bodies while preserving tool event order', async () => {
+    const initial = openTerminalSseResponse(
+      'resp_tool_call',
+      'response.completed',
+      [TOOL_CALL],
+    );
+    const followUp = openTerminalSseResponse(
+      'resp_final',
+      'response.completed',
+      [FINAL_MESSAGE],
+    );
+    const { client, requestCount } = clientWithResponses([
+      initial.response,
+      followUp.response,
+    ]);
+    const result = callModel(client, {
+      model: 'test/model',
+      input: 'Check the weather',
+      tools: [WEATHER_TOOL],
     });
 
     const events = await Array.fromAsync(result.getFullResponsesStream());
@@ -157,18 +241,31 @@ describe('ModelResult replay-buffer compaction', () => {
     expect(events.filter((event) => event.type === 'response.completed')).toHaveLength(2);
     expect(events.filter((event) => event.type === 'tool.result')).toHaveLength(1);
     expect(eventTypes.indexOf('turn.end')).toBeLessThan(eventTypes.indexOf('tool.result'));
+    expect(initial.cancellationCount()).toBe(1);
+    expect(followUp.cancellationCount()).toBe(1);
   });
 });
 
 interface TestClient {
   readonly client: OpenRouterCore;
   readonly requestCount: () => number;
+  readonly requestBodies: () => readonly Record<string, unknown>[];
 }
 
 function clientWithResponses(responses: readonly Response[]): TestClient {
   let requestCount = 0;
+  const requestBodies: Record<string, unknown>[] = [];
   const httpClient = new HTTPClient({
-    async fetcher(): Promise<Response> {
+    async fetcher(input): Promise<Response> {
+      if (!(input instanceof Request)) {
+        throw new TypeError('Expected the SDK to send a Request instance');
+      }
+      const body: unknown = await input.clone().json();
+      if (!isRecord(body)) {
+        throw new TypeError('Expected the SDK request body to be a JSON object');
+      }
+      requestBodies.push(body);
+
       const response = responses[requestCount];
       requestCount++;
       if (!response) {
@@ -184,6 +281,7 @@ function clientWithResponses(responses: readonly Response[]): TestClient {
       httpClient,
     }),
     requestCount: () => requestCount,
+    requestBodies: () => requestBodies,
   };
 }
 
@@ -254,13 +352,86 @@ function textDeltaEvent(delta: string, sequenceNumber = 1): Record<string, unkno
   };
 }
 
+type TerminalEventType =
+  | 'response.completed'
+  | 'response.failed'
+  | 'response.incomplete';
+
+interface OpenTerminalResponse {
+  readonly response: Response;
+  readonly cancellationCount: () => number;
+}
+
+function openTerminalSseResponse(
+  id: string,
+  terminalType: TerminalEventType,
+  output: readonly unknown[],
+  shouldCancellationFail = false,
+  intermediateEvents: readonly Record<string, unknown>[] = [],
+): OpenTerminalResponse {
+  let cancellationCount = 0;
+  const response = {
+    ...RESPONSE_BASE,
+    id,
+    output,
+    status: terminalType.replace('response.', ''),
+    error: terminalType === 'response.failed'
+      ? {
+          code: 'server_error',
+          message: 'upstream provider failed',
+        }
+      : null,
+    incomplete_details: terminalType === 'response.incomplete'
+      ? {
+          reason: 'max_output_tokens',
+        }
+      : null,
+  };
+  const events = [
+    createdEvent(response),
+    ...intermediateEvents,
+    {
+      type: terminalType,
+      sequence_number: intermediateEvents.length + 1,
+      response,
+    },
+  ];
+  const body = new ReadableStream<Uint8Array>({
+    start(controller): void {
+      controller.enqueue(new TextEncoder().encode(serializeSse(events)));
+    },
+    cancel(): void {
+      cancellationCount++;
+      if (shouldCancellationFail) {
+        throw new Error('source cancellation failed');
+      }
+    },
+  });
+
+  return {
+    response: new Response(body, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+      },
+    }),
+    cancellationCount: () => cancellationCount,
+  };
+}
+
 function sseResponse(events: readonly Record<string, unknown>[]): Response {
-  const body = events
-    .map((event) => `event: ${String(event['type'])}\ndata: ${JSON.stringify(event)}\n\n`)
-    .join('');
-  return new Response(body, {
+  return new Response(serializeSse(events), {
     headers: {
       'Content-Type': 'text/event-stream',
     },
   });
+}
+
+function serializeSse(events: readonly Record<string, unknown>[]): string {
+  return events
+    .map((event) => `event: ${String(event['type'])}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join('');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/tests/unit/model-result-replay-compaction.test.ts
+++ b/tests/unit/model-result-replay-compaction.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+
+import { OpenRouterCore } from '../../src/core.js';
+import { callModel } from '../../src/funcs/call-model.js';
+import { HTTPClient } from '../../src/lib/http.js';
+import { tool } from '../../src/lib/tool.js';
+
+const RESPONSE_BASE = {
+  object: 'response',
+  status: 'completed',
+  completed_at: 1_783_462_520,
+  created_at: 1_783_462_506,
+  error: null,
+  frequency_penalty: 0,
+  incomplete_details: null,
+  instructions: null,
+  max_output_tokens: null,
+  max_tool_calls: null,
+  metadata: null,
+  model: 'test/model',
+  parallel_tool_calls: true,
+  presence_penalty: 0,
+  previous_response_id: null,
+  prompt_cache_key: null,
+  reasoning: null,
+  safety_identifier: null,
+  service_tier: null,
+  temperature: 1,
+  text: {
+    format: {
+      type: 'text',
+    },
+    verbosity: null,
+  },
+  tool_choice: 'auto',
+  tools: [],
+  top_logprobs: 0,
+  top_p: 1,
+  truncation: null,
+  usage: null,
+  user: null,
+  background: null,
+  store: false,
+} as const;
+
+const FINAL_MESSAGE = {
+  type: 'message',
+  id: 'msg_final',
+  role: 'assistant',
+  status: 'completed',
+  content: [
+    {
+      type: 'output_text',
+      text: 'hello',
+      annotations: [],
+      logprobs: [],
+    },
+  ],
+} as const;
+
+const TOOL_CALL = {
+  type: 'function_call',
+  id: 'fc_weather',
+  call_id: 'call_weather',
+  name: 'weather',
+  arguments: '{"city":"Denver"}',
+  status: 'completed',
+} as const;
+
+describe('ModelResult replay-buffer compaction', () => {
+  it('returns the final response after getTextStream drains trimmed events', async () => {
+    const { client } = clientWithResponses([
+      completedSseResponse('resp_text', [FINAL_MESSAGE], [textDeltaEvent('hello')]),
+    ]);
+    const result = callModel(client, {
+      model: 'test/model',
+      input: 'Say hello',
+    });
+
+    expect(await Array.fromAsync(result.getTextStream())).toEqual(['hello']);
+
+    const response = await result.getResponse();
+    expect(response.id).toBe('resp_text');
+    expect(await result.getText()).toBe('hello');
+  });
+
+  it('returns tool calls after getFullResponsesStream drains trimmed events', async () => {
+    const { client } = clientWithResponses([
+      completedSseResponse('resp_tool_call', [TOOL_CALL]),
+    ]);
+    const result = callModel(client, {
+      model: 'test/model',
+      input: 'Check the weather',
+    });
+
+    await Array.fromAsync(result.getFullResponsesStream());
+
+    expect(await result.getToolCalls()).toEqual([
+      {
+        id: 'call_weather',
+        name: 'weather',
+        arguments: {
+          city: 'Denver',
+        },
+      },
+    ]);
+  });
+
+  it('preserves a terminal provider error after the event buffer is trimmed', async () => {
+    const { client } = clientWithResponses([
+      failedSseResponse('resp_failed', 'upstream provider failed'),
+    ]);
+    const result = callModel(client, {
+      model: 'test/model',
+      input: 'Fail this request',
+    });
+
+    await Array.fromAsync(result.getFullResponsesStream());
+
+    await expect(result.getResponse()).rejects.toThrow('upstream provider failed');
+  });
+
+  it('coordinates the initial pipe with an immediate streaming tool response', async () => {
+    const panelTool = tool({
+      name: 'weather',
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      outputSchema: z.object({
+        temperature: z.number(),
+      }),
+      async execute(): Promise<{ temperature: number }> {
+        return {
+          temperature: 72,
+        };
+      },
+    });
+    const { client, requestCount } = clientWithResponses([
+      completedSseResponse(
+        'resp_tool_call',
+        [TOOL_CALL],
+        Array.from({ length: 256 }, (_, index) => textDeltaEvent('x', index + 1)),
+      ),
+      completedSseResponse('resp_final', [FINAL_MESSAGE]),
+    ]);
+    const result = callModel(client, {
+      model: 'test/model',
+      input: 'Check the weather',
+      tools: [panelTool],
+    });
+
+    const events = await Array.fromAsync(result.getFullResponsesStream());
+    const eventTypes = events.map((event) => event.type);
+
+    expect(requestCount()).toBe(2);
+    expect(events.filter((event) => event.type === 'response.completed')).toHaveLength(2);
+    expect(events.filter((event) => event.type === 'tool.result')).toHaveLength(1);
+    expect(eventTypes.indexOf('turn.end')).toBeLessThan(eventTypes.indexOf('tool.result'));
+  });
+});
+
+interface TestClient {
+  readonly client: OpenRouterCore;
+  readonly requestCount: () => number;
+}
+
+function clientWithResponses(responses: readonly Response[]): TestClient {
+  let requestCount = 0;
+  const httpClient = new HTTPClient({
+    async fetcher(): Promise<Response> {
+      const response = responses[requestCount];
+      requestCount++;
+      if (!response) {
+        throw new Error(`Unexpected SDK request ${requestCount}`);
+      }
+      return response;
+    },
+  });
+
+  return {
+    client: new OpenRouterCore({
+      apiKey: 'test-key',
+      httpClient,
+    }),
+    requestCount: () => requestCount,
+  };
+}
+
+function completedSseResponse(
+  id: string,
+  output: readonly unknown[],
+  intermediateEvents: readonly Record<string, unknown>[] = [],
+): Response {
+  const response = {
+    ...RESPONSE_BASE,
+    id,
+    output,
+  };
+  return sseResponse([
+    createdEvent(response),
+    ...intermediateEvents,
+    {
+      type: 'response.completed',
+      sequence_number: intermediateEvents.length + 1,
+      response,
+    },
+  ]);
+}
+
+function failedSseResponse(id: string, message: string): Response {
+  const response = {
+    ...RESPONSE_BASE,
+    id,
+    status: 'failed',
+    error: {
+      code: 'server_error',
+      message,
+    },
+    output: [],
+  };
+  return sseResponse([
+    createdEvent(response),
+    {
+      type: 'response.failed',
+      sequence_number: 1,
+      response,
+    },
+  ]);
+}
+
+function createdEvent(response: Record<string, unknown>): Record<string, unknown> {
+  return {
+    type: 'response.created',
+    sequence_number: 0,
+    response: {
+      ...response,
+      status: 'in_progress',
+      error: null,
+      output: [],
+    },
+  };
+}
+
+function textDeltaEvent(delta: string, sequenceNumber = 1): Record<string, unknown> {
+  return {
+    type: 'response.output_text.delta',
+    sequence_number: sequenceNumber,
+    item_id: 'msg_final',
+    output_index: 0,
+    content_index: 0,
+    delta,
+    logprobs: [],
+  };
+}
+
+function sseResponse(events: readonly Record<string, unknown>[]): Response {
+  const body = events
+    .map((event) => `event: ${String(event['type'])}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join('');
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+    },
+  });
+}

--- a/tests/unit/replay-buffer-compaction.test.ts
+++ b/tests/unit/replay-buffer-compaction.test.ts
@@ -8,9 +8,19 @@ const PARTIAL_DRAIN_SIZE = 3073;
 const APPENDED_BACKLOG_SIZE = 4096;
 
 describe('SDK replay-buffer compaction', () => {
+  it('keeps full broadcaster replay by default for sequential post-completion consumers', async () => {
+    const broadcaster = new ToolEventBroadcaster<number>();
+    broadcaster.push(1);
+    broadcaster.push(2);
+    broadcaster.complete();
+
+    expect(await Array.fromAsync(broadcaster.createConsumer())).toEqual([1, 2]);
+    expect(await Array.fromAsync(broadcaster.createConsumer())).toEqual([1, 2]);
+  });
+
   it('delivers a large buffered event backlog in order to every attached consumer', async () => {
     const values = numberedValues(LARGE_BACKLOG_SIZE);
-    const broadcaster = new ToolEventBroadcaster<number>();
+    const broadcaster = new ToolEventBroadcaster<number>('active-consumers');
     const fast = broadcaster.createConsumer();
     const slow = broadcaster.createConsumer();
 
@@ -24,7 +34,7 @@ describe('SDK replay-buffer compaction', () => {
   });
 
   it('starts late event consumers after data released when a lagging consumer returns', async () => {
-    const broadcaster = new ToolEventBroadcaster<number>();
+    const broadcaster = new ToolEventBroadcaster<number>('active-consumers');
     const fast = broadcaster.createConsumer();
     const slow = broadcaster.createConsumer();
     [1, 2, 3].forEach((value) => broadcaster.push(value));
@@ -42,7 +52,7 @@ describe('SDK replay-buffer compaction', () => {
   });
 
   it('starts late event consumers after data released when a lagging consumer throws', async () => {
-    const broadcaster = new ToolEventBroadcaster<number>();
+    const broadcaster = new ToolEventBroadcaster<number>('active-consumers');
     const fast = broadcaster.createConsumer();
     const slow = broadcaster.createConsumer();
     [1, 2, 3].forEach((value) => broadcaster.push(value));
@@ -61,7 +71,7 @@ describe('SDK replay-buffer compaction', () => {
   });
 
   it('preserves the unread event suffix after the last consumer returns', async () => {
-    const broadcaster = new ToolEventBroadcaster<number>();
+    const broadcaster = new ToolEventBroadcaster<number>('active-consumers');
     const first = broadcaster.createConsumer();
     [1, 2, 3].forEach((value) => broadcaster.push(value));
     expect((await first.next()).value).toBe(1);
@@ -78,7 +88,7 @@ describe('SDK replay-buffer compaction', () => {
     const initial = valuesWithUndefined(0, LARGE_BACKLOG_SIZE);
     const appended = valuesWithUndefined(LARGE_BACKLOG_SIZE, APPENDED_BACKLOG_SIZE);
     const expected = [...initial, ...appended];
-    const broadcaster = new ToolEventBroadcaster<number | undefined>();
+    const broadcaster = new ToolEventBroadcaster<number | undefined>('active-consumers');
     const fast = broadcaster.createConsumer();
     const slow = broadcaster.createConsumer();
     initial.forEach((value) => broadcaster.push(value));
@@ -108,7 +118,7 @@ describe('SDK replay-buffer compaction', () => {
   });
 
   it('delivers buffered events before throwing the terminal error', async () => {
-    const broadcaster = new ToolEventBroadcaster<number>();
+    const broadcaster = new ToolEventBroadcaster<number>('active-consumers');
     const consumer = broadcaster.createConsumer();
     const error = new Error('terminal broadcaster error');
     broadcaster.push(1);
@@ -120,11 +130,42 @@ describe('SDK replay-buffer compaction', () => {
     await expect(consumer.next()).rejects.toBe(error);
   });
 
+  it('keeps full stream replay by default for sequential post-completion consumers', async () => {
+    const stream = new ReusableReadableStream<number>(streamOf([1, 2]));
+
+    expect(await Array.fromAsync(stream.createConsumer())).toEqual([1, 2]);
+    expect(await Array.fromAsync(stream.createConsumer())).toEqual([1, 2]);
+  });
+
+  it('treats a terminal value as authoritative when source cancellation fails', async () => {
+    let cancellationCount = 0;
+    const source = new ReadableStream<number>({
+      start(controller): void {
+        controller.enqueue(1);
+        controller.enqueue(2);
+      },
+      cancel(): void {
+        cancellationCount++;
+        throw new Error('source cancellation failed');
+      },
+    });
+    const stream = new ReusableReadableStream(source, {
+      isTerminalValue: (value) => value === 2,
+    });
+
+    expect(await Array.fromAsync(stream.createConsumer())).toEqual([1, 2]);
+    await yieldToStreamPump();
+    expect(cancellationCount).toBe(1);
+    expect(source.locked).toBe(false);
+  });
+
   it('delivers a large buffered stream backlog including undefined values in order', async () => {
     const values = Array.from({ length: LARGE_BACKLOG_SIZE }, (_, index) =>
       index % 1024 === 0 ? undefined : index,
     );
-    const stream = new ReusableReadableStream<number | undefined>(streamOf(values));
+    const stream = new ReusableReadableStream<number | undefined>(streamOf(values), {
+      streamReplay: 'active-consumers',
+    });
     const fast = stream.createConsumer();
     const slow = stream.createConsumer();
 
@@ -136,7 +177,9 @@ describe('SDK replay-buffer compaction', () => {
   });
 
   it('starts late stream consumers after data released when a lagging consumer returns', async () => {
-    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]));
+    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]), {
+      streamReplay: 'active-consumers',
+    });
     const fast = stream.createConsumer();
     const slow = stream.createConsumer();
     expect((await fast.next()).value).toBe(1);
@@ -151,7 +194,9 @@ describe('SDK replay-buffer compaction', () => {
   });
 
   it('starts late stream consumers after data released when a lagging consumer throws', async () => {
-    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]));
+    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]), {
+      streamReplay: 'active-consumers',
+    });
     const fast = stream.createConsumer();
     const slow = stream.createConsumer();
     expect((await fast.next()).value).toBe(1);
@@ -167,7 +212,9 @@ describe('SDK replay-buffer compaction', () => {
   });
 
   it('preserves the unread stream suffix after the last consumer returns', async () => {
-    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]));
+    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]), {
+      streamReplay: 'active-consumers',
+    });
     const first = stream.createConsumer();
     expect((await first.next()).value).toBe(1);
 
@@ -194,7 +241,9 @@ describe('SDK replay-buffer compaction', () => {
       throw new Error('ReadableStream did not initialize its controller');
     }
     initial.forEach((value) => controller.enqueue(value));
-    const stream = new ReusableReadableStream<number | undefined>(source);
+    const stream = new ReusableReadableStream<number | undefined>(source, {
+      streamReplay: 'active-consumers',
+    });
     const fast = stream.createConsumer();
     const slow = stream.createConsumer();
     await yieldToStreamPump();

--- a/tests/unit/replay-buffer-compaction.test.ts
+++ b/tests/unit/replay-buffer-compaction.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+
+import { ReusableReadableStream } from '../../src/lib/reusable-stream.js';
+import { ToolEventBroadcaster } from '../../src/lib/tool-event-broadcaster.js';
+
+const LARGE_BACKLOG_SIZE = 4097;
+const PARTIAL_DRAIN_SIZE = 3073;
+const APPENDED_BACKLOG_SIZE = 4096;
+
+describe('SDK replay-buffer compaction', () => {
+  it('delivers a large buffered event backlog in order to every attached consumer', async () => {
+    const values = numberedValues(LARGE_BACKLOG_SIZE);
+    const broadcaster = new ToolEventBroadcaster<number>();
+    const fast = broadcaster.createConsumer();
+    const slow = broadcaster.createConsumer();
+
+    values.forEach((value) => broadcaster.push(value));
+    broadcaster.complete();
+    const fastValues = await Array.fromAsync(fast);
+    const slowValues = await Array.fromAsync(slow);
+
+    expect(fastValues).toEqual(values);
+    expect(slowValues).toEqual(values);
+  });
+
+  it('starts late event consumers after data released when a lagging consumer returns', async () => {
+    const broadcaster = new ToolEventBroadcaster<number>();
+    const fast = broadcaster.createConsumer();
+    const slow = broadcaster.createConsumer();
+    [1, 2, 3].forEach((value) => broadcaster.push(value));
+    expect((await fast.next()).value).toBe(1);
+    expect((await fast.next()).value).toBe(2);
+    expect((await fast.next()).value).toBe(3);
+
+    expect(await slow.return?.()).toEqual({ done: true, value: undefined });
+    const late = broadcaster.createConsumer();
+    broadcaster.push(4);
+    broadcaster.complete();
+
+    expect(await Array.fromAsync(late)).toEqual([4]);
+    expect(await Array.fromAsync(fast)).toEqual([4]);
+  });
+
+  it('starts late event consumers after data released when a lagging consumer throws', async () => {
+    const broadcaster = new ToolEventBroadcaster<number>();
+    const fast = broadcaster.createConsumer();
+    const slow = broadcaster.createConsumer();
+    [1, 2, 3].forEach((value) => broadcaster.push(value));
+    expect((await fast.next()).value).toBe(1);
+    expect((await fast.next()).value).toBe(2);
+    expect((await fast.next()).value).toBe(3);
+    const error = new Error('stop lagging event consumer');
+
+    await expect(slow.throw?.(error)).rejects.toBe(error);
+    const late = broadcaster.createConsumer();
+    broadcaster.push(4);
+    broadcaster.complete();
+
+    expect(await Array.fromAsync(late)).toEqual([4]);
+    expect(await Array.fromAsync(fast)).toEqual([4]);
+  });
+
+  it('preserves the unread event suffix after the last consumer returns', async () => {
+    const broadcaster = new ToolEventBroadcaster<number>();
+    const first = broadcaster.createConsumer();
+    [1, 2, 3].forEach((value) => broadcaster.push(value));
+    expect((await first.next()).value).toBe(1);
+
+    expect(await first.return?.()).toEqual({ done: true, value: undefined });
+    const late = broadcaster.createConsumer();
+    broadcaster.push(4);
+    broadcaster.complete();
+
+    expect(await Array.fromAsync(late)).toEqual([2, 3, 4]);
+  });
+
+  it('preserves event order across repeated compactions and later appends', async () => {
+    const initial = valuesWithUndefined(0, LARGE_BACKLOG_SIZE);
+    const appended = valuesWithUndefined(LARGE_BACKLOG_SIZE, APPENDED_BACKLOG_SIZE);
+    const expected = [...initial, ...appended];
+    const broadcaster = new ToolEventBroadcaster<number | undefined>();
+    const fast = broadcaster.createConsumer();
+    const slow = broadcaster.createConsumer();
+    initial.forEach((value) => broadcaster.push(value));
+
+    const [fastPrefix, slowPrefix] = await readInLockstep(fast, slow, PARTIAL_DRAIN_SIZE);
+    expect(fastPrefix).toEqual(initial.slice(0, PARTIAL_DRAIN_SIZE));
+    expect(slowPrefix).toEqual(initial.slice(0, PARTIAL_DRAIN_SIZE));
+    expect(replayBufferState(broadcaster)).toEqual({
+      bufferLength: LARGE_BACKLOG_SIZE - PARTIAL_DRAIN_SIZE,
+      bufferHead: 0,
+      trimOffset: PARTIAL_DRAIN_SIZE,
+    });
+
+    appended.forEach((value) => broadcaster.push(value));
+    expect(replayBufferState(broadcaster).bufferLength).toBe(
+      LARGE_BACKLOG_SIZE - PARTIAL_DRAIN_SIZE + APPENDED_BACKLOG_SIZE,
+    );
+    broadcaster.complete();
+
+    expect([...fastPrefix, ...(await Array.fromAsync(fast))]).toEqual(expected);
+    expect([...slowPrefix, ...(await Array.fromAsync(slow))]).toEqual(expected);
+    expect(replayBufferState(broadcaster)).toEqual({
+      bufferLength: 0,
+      bufferHead: 0,
+      trimOffset: expected.length,
+    });
+  });
+
+  it('delivers buffered events before throwing the terminal error', async () => {
+    const broadcaster = new ToolEventBroadcaster<number>();
+    const consumer = broadcaster.createConsumer();
+    const error = new Error('terminal broadcaster error');
+    broadcaster.push(1);
+    broadcaster.push(2);
+    broadcaster.complete(error);
+
+    expect((await consumer.next()).value).toBe(1);
+    expect((await consumer.next()).value).toBe(2);
+    await expect(consumer.next()).rejects.toBe(error);
+  });
+
+  it('delivers a large buffered stream backlog including undefined values in order', async () => {
+    const values = Array.from({ length: LARGE_BACKLOG_SIZE }, (_, index) =>
+      index % 1024 === 0 ? undefined : index,
+    );
+    const stream = new ReusableReadableStream<number | undefined>(streamOf(values));
+    const fast = stream.createConsumer();
+    const slow = stream.createConsumer();
+
+    const fastValues = await Array.fromAsync(fast);
+    const slowValues = await Array.fromAsync(slow);
+
+    expect(fastValues).toEqual(values);
+    expect(slowValues).toEqual(values);
+  });
+
+  it('starts late stream consumers after data released when a lagging consumer returns', async () => {
+    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]));
+    const fast = stream.createConsumer();
+    const slow = stream.createConsumer();
+    expect((await fast.next()).value).toBe(1);
+    expect((await fast.next()).value).toBe(2);
+    expect((await fast.next()).value).toBe(3);
+
+    expect(await slow.return?.()).toEqual({ done: true, value: undefined });
+    const late = stream.createConsumer();
+
+    expect(await Array.fromAsync(late)).toEqual([]);
+    expect((await fast.next()).done).toBe(true);
+  });
+
+  it('starts late stream consumers after data released when a lagging consumer throws', async () => {
+    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]));
+    const fast = stream.createConsumer();
+    const slow = stream.createConsumer();
+    expect((await fast.next()).value).toBe(1);
+    expect((await fast.next()).value).toBe(2);
+    expect((await fast.next()).value).toBe(3);
+    const error = new Error('stop lagging stream consumer');
+
+    await expect(slow.throw?.(error)).rejects.toBe(error);
+    const late = stream.createConsumer();
+
+    expect(await Array.fromAsync(late)).toEqual([]);
+    expect((await fast.next()).done).toBe(true);
+  });
+
+  it('preserves the unread stream suffix after the last consumer returns', async () => {
+    const stream = new ReusableReadableStream<number>(streamOf([1, 2, 3]));
+    const first = stream.createConsumer();
+    expect((await first.next()).value).toBe(1);
+
+    expect(await first.return?.()).toEqual({ done: true, value: undefined });
+    const late = stream.createConsumer();
+
+    expect(await Array.fromAsync(late)).toEqual([2, 3]);
+  });
+
+  it('preserves stream order across repeated compactions and later appends', async () => {
+    const initial = valuesWithUndefined(0, LARGE_BACKLOG_SIZE);
+    const appended = valuesWithUndefined(LARGE_BACKLOG_SIZE, APPENDED_BACKLOG_SIZE);
+    const expected = [...initial, ...appended];
+    const sourceState: {
+      controller?: ReadableStreamDefaultController<number | undefined>;
+    } = {};
+    const source = new ReadableStream<number | undefined>({
+      start(controller): void {
+        sourceState.controller = controller;
+      },
+    });
+    const controller = sourceState.controller;
+    if (!controller) {
+      throw new Error('ReadableStream did not initialize its controller');
+    }
+    initial.forEach((value) => controller.enqueue(value));
+    const stream = new ReusableReadableStream<number | undefined>(source);
+    const fast = stream.createConsumer();
+    const slow = stream.createConsumer();
+    await yieldToStreamPump();
+
+    const [fastPrefix, slowPrefix] = await readInLockstep(fast, slow, PARTIAL_DRAIN_SIZE);
+    expect(fastPrefix).toEqual(initial.slice(0, PARTIAL_DRAIN_SIZE));
+    expect(slowPrefix).toEqual(initial.slice(0, PARTIAL_DRAIN_SIZE));
+    expect(replayBufferState(stream)).toEqual({
+      bufferLength: LARGE_BACKLOG_SIZE - PARTIAL_DRAIN_SIZE,
+      bufferHead: 0,
+      trimOffset: PARTIAL_DRAIN_SIZE,
+    });
+
+    appended.forEach((value) => controller.enqueue(value));
+    controller.close();
+    await yieldToStreamPump();
+    expect(replayBufferState(stream).bufferLength).toBe(
+      LARGE_BACKLOG_SIZE - PARTIAL_DRAIN_SIZE + APPENDED_BACKLOG_SIZE,
+    );
+
+    expect([...fastPrefix, ...(await Array.fromAsync(fast))]).toEqual(expected);
+    expect([...slowPrefix, ...(await Array.fromAsync(slow))]).toEqual(expected);
+    expect(replayBufferState(stream)).toEqual({
+      bufferLength: 0,
+      bufferHead: 0,
+      trimOffset: expected.length,
+    });
+  });
+});
+
+interface ReplayBufferState {
+  readonly bufferLength: number;
+  readonly bufferHead: number;
+  readonly trimOffset: number;
+}
+
+async function readInLockstep<T>(
+  first: AsyncIterableIterator<T>,
+  second: AsyncIterableIterator<T>,
+  count: number,
+): Promise<readonly [T[], T[]]> {
+  const firstValues: T[] = [];
+  const secondValues: T[] = [];
+  for (let index = 0; index < count; index++) {
+    firstValues.push(await nextValue(first));
+    secondValues.push(await nextValue(second));
+  }
+  return [firstValues, secondValues];
+}
+
+async function nextValue<T>(iterator: AsyncIterableIterator<T>): Promise<T> {
+  const result = await iterator.next();
+  if (result.done) {
+    throw new Error('Replay consumer completed before the expected value');
+  }
+  return result.value;
+}
+
+function replayBufferState(value: object): ReplayBufferState {
+  const buffer: unknown = Reflect.get(value, 'buffer');
+  const bufferHead: unknown = Reflect.get(value, 'bufferHead');
+  const trimOffset: unknown = Reflect.get(value, 'trimOffset');
+  if (!Array.isArray(buffer) || typeof bufferHead !== 'number' || typeof trimOffset !== 'number') {
+    throw new TypeError('Replay buffer internals did not match the expected SDK shape');
+  }
+  return {
+    bufferLength: buffer.length,
+    bufferHead,
+    trimOffset,
+  };
+}
+
+function numberedValues(size: number): number[] {
+  return Array.from({ length: size }, (_, index) => index);
+}
+
+function valuesWithUndefined(start: number, size: number): (number | undefined)[] {
+  return Array.from({ length: size }, (_, offset) =>
+    offset % 1024 === 0 ? undefined : start + offset,
+  );
+}
+
+function streamOf<T>(values: readonly T[]): ReadableStream<T> {
+  return new ReadableStream<T>({
+    start(controller): void {
+      values.forEach((value) => controller.enqueue(value));
+      controller.close();
+    },
+  });
+}
+
+async function yieldToStreamPump(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}

--- a/tests/unit/tool-event-broadcaster.test.ts
+++ b/tests/unit/tool-event-broadcaster.test.ts
@@ -82,7 +82,7 @@ describe('ToolEventBroadcaster', () => {
     });
 
     it('should start late consumers at the trim watermark', async () => {
-      const broadcaster = new ToolEventBroadcaster<number>();
+      const broadcaster = new ToolEventBroadcaster<number>('active-consumers');
       const consumer1 = broadcaster.createConsumer();
 
       broadcaster.push(1);

--- a/tests/unit/tool-event-broadcaster.test.ts
+++ b/tests/unit/tool-event-broadcaster.test.ts
@@ -81,7 +81,7 @@ describe('ToolEventBroadcaster', () => {
       expect(results2).toEqual(['a', 'b']);
     });
 
-    it('should allow consumers at different read positions', async () => {
+    it('should start late consumers at the trim watermark', async () => {
       const broadcaster = new ToolEventBroadcaster<number>();
       const consumer1 = broadcaster.createConsumer();
 
@@ -103,10 +103,10 @@ describe('ToolEventBroadcaster', () => {
       for await (const e of consumer1) remaining1.push(e);
       expect(remaining1).toEqual([2, 3]);
 
-      // Consumer 2 gets all events from position 0
+      // Consumer 2 starts at the trim watermark after event 1 was consumed
       const all2: number[] = [];
       for await (const e of consumer2) all2.push(e);
-      expect(all2).toEqual([1, 2, 3]);
+      expect(all2).toEqual([2, 3]);
     });
   });
 


### PR DESCRIPTION
## Summary

`ToolEventBroadcaster` and `ReusableReadableStream` previously retained every replayed event for the lifetime of a `callModel()` run. That is expensive for long generator-tool streams in a constrained runtime, but replay is also a public compatibility contract: delayed and sequential stream getters must still be able to start from event zero.

This PR now makes that tradeoff explicit:

- `streamReplay: 'full'` is the default and preserves historical behavior for delayed, sequential, and post-completion consumers.
- `streamReplay: 'active-consumers'` opts a call into watermark compaction. Entries are released after every currently attached consumer advances past them.
- The policy is threaded through `callModel`, `ModelResult`, initial/follow-up `ReusableReadableStream` instances, and the turn `ToolEventBroadcaster`.
- `streamReplay` is client-only: it is stripped from both the initial request and reconstructed follow-up request bodies.

The PR also fixes a related stream-lifecycle issue: providers can send an authoritative `response.completed`, `response.failed`, or `response.incomplete` SSE event without closing the HTTP body. The replay pump now buffers and broadcasts that terminal event, marks itself complete, cancels the source reader once, and releases its lock once. Cancellation failure is cleanup-only and cannot replace the provider's terminal result. This applies to initial and follow-up responses, so tool execution can continue without waiting forever for EOF.

## Compaction mechanism

In opt-in `active-consumers` mode, consumer positions are absolute and monotonic while the backing array carries a logical head:

```ts
physicalIndex = bufferHead + consumer.position - trimOffset
```

`trimConsumed()` runs after every successful read and after `return()`/`throw()` deregisters a consumer:

```ts
const nextHead = bufferHead + minConsumerPosition - trimOffset;
if (nextHead <= bufferHead) return;
trimOffset = minConsumerPosition;
buffer.fill(undefined, bufferHead, nextHead);        // release referents now
if (nextHead >= 1024 && nextHead * 2 >= buffer.length) {
  buffer = buffer.slice(nextHead);                    // amortized physical copy
  bufferHead = 0;
} else {
  bufferHead = nextHead;                              // O(1) common case
}
```

Clearing slots releases payload referents immediately. The physical copy only bounds backing-array length, so it is gated on 1,024 dead entries occupying at least half the array. This avoids the quadratic live-suffix shifting of `splice(0, n)` while inference fetch promises share the isolate.

## Compatibility and complexity/reward

The compatibility-safe default does not claim a memory reduction: full replay intentionally retains history. Workloads that attach all consumers before draining can opt into `active-consumers` and receive the measured CPU/memory benefits below. `ModelResult` also caches terminal responses/errors so aggregate getters remain correct in active mode.

The added surface is one two-value option plus a narrow terminal predicate. That complexity is justified because it keeps the existing SDK contract intact, makes the memory tradeoff explicit at each call site, and prevents an open terminal body from indefinitely blocking aggregate getters or multi-turn tool follow-ups.

## Testing

- Focused replay/lifecycle regression suite: **39/39 tests passed** across `replay-buffer-compaction`, `model-result-replay-compaction`, `tool-event-broadcaster`, and `turn-end-race-condition`.
- Full unit suite: **17 files, 213/213 tests passed; zero type errors**.
- `npm run lint`: passed.
- `npm run typecheck`: passed.
- `npm run build`: passed.

Coverage includes:

- default full replay for sequential and post-completion consumers in both replay classes;
- explicit active-consumer watermark behavior and repeated amortized compaction;
- sequential `ModelResult` stream getters under the default contract;
- active-mode aggregate response/tool/error caching;
- absence of `streamReplay` from captured initial and follow-up HTTP JSON;
- open bodies ending at completed, failed, and incomplete events;
- exactly-once cancellation, cancellation failure, and reader-lock release;
- an open initial tool response continuing into an open follow-up response with `turn.end` emitted before `tool.result`.

Per session direction, local E2E tests were not run; the PR validation workflow remains authoritative for repository integration gates.

<details>
<summary>Performance evidence for opt-in <code>active-consumers</code> mode</summary>

Measured in openrouter-web [#33459](https://github.com/OpenRouterTeam/openrouter-web/pull/33459) against the same compaction logic applied to the published package's `esm/`, not against this branch's build. Production-flag Miniflare/workerd, strict alternating A/B blocks, 8 warmups + 31 recorded samples per block, 2,480 recorded samples across a 20-scenario matrix; counts, checksums, and backlog shape asserted on every sample.

| 50k-event shape | Payload | Operation median | p90 |
|---|---:|---:|---:|
| Broadcaster burst | 64 B | 66 → **2 ms** | 79 → **3 ms** |
| Broadcaster burst | 1 KiB | 74.5 → **7 ms** | 81 → **11 ms** |
| Reusable burst | 64 B | 68 → **3 ms** | 1,907 → **7 ms** |
| Reusable burst | 1 KiB | 74 → **8 ms** | 75 → **9 ms** |
| Broadcaster staggered (2 consumers) | 64 B | 902 → **7 ms** | 2,509 → **9 ms** |
| Reusable staggered (2 consumers) | 64 B | 535 → **4 ms** | 2,512 → **9 ms** |

Ready-scheduler and service-binding starvation probes improved one-for-one with the drain (broadcaster staggered 902.5 → 7 ms scheduler, 902 → 7 ms service binding).

Cost side, from a separate 1,984-sample paired run: normal 10k streaming is flat within the 0.5 ms timer floor; in an artificial fully-lockstep 50k × 1 KiB extreme the bookkeeping costs +1 ms total for the broadcaster (~20 ns/event) and +3 ms for the reusable stream (~60 ns/event).

Capacity was checked at exact V8 limits over 108 serial Node subprocesses (55 passes, 53 intentional OOMs, zero unexpected outcomes). Last-passing event counts moved by ≤0.23% in both directions — noise. Active mode preserves the prior OOM boundary while releasing consumed payloads; it cannot shrink a genuinely unread backlog.

</details>

## Review resolutions

| Thread | Verdict | Detail |
| --- | --- | --- |
| [Replay compatibility regression](https://github.com/OpenRouterTeam/typescript-sdk/pull/798#discussion_r3762951238) | Fixed | Restored full replay by default, made watermark compaction opt-in, retained terminal aggregate caching, and added sequential/delayed/payload regressions in `d2a7becb`. |

Link to Devin session: https://openrouter.devinenterprise.com/sessions/16a30107ee1c4a8dbf1974c027822d8f

Requested by: @sambarnes

<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-sdk/pull/798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
