### PR TITLE
fix(lib): derive NextTurnParamsContext.models from the generated request type

### DIFF
--- a/src/lib/tool-types.ts
+++ b/src/lib/tool-types.ts
@@ -99,8 +99,8 @@ export type NextTurnParamsContext = {
   input: models.InputsUnion;
   /** Current model selection */
   model: string;
-  /** Current models array */
-  models: string[];
+  /** Current models array (fallback model IDs or reason-gated entries) */
+  models: NonNullable<models.ResponsesRequest['models']>;
   /** Current temperature */
   temperature: number | null;
   /** Current maxOutputTokens */


### PR DESCRIPTION
## What

Replaces the hand-written `models: string[]` on `NextTurnParamsContext` with `NonNullable<models.ResponsesRequest['models']>`, deriving it from the generated request type.

## Why

[openrouter-web#34136](https://github.com/OpenRouterTeam/openrouter-web/pull/34136) introduces reason-gated fallback entries: the `models` array becomes `(string | ReasonGatedFallbackModel)[]`. The upstream `sdk-build-check (typescript)` CI job fails on that PR because this hand-written type no longer matches:

```
src/lib/next-turn-params.ts(24,5): error TS2322: Type '(string | ReasonGatedFallbackModel)[]' is not assignable to type 'string[]'.
```

Deriving the field keeps it in lockstep with the generated `ResponsesRequest` — `string[]` today, the union after the spec regenerates, with no further edits needed. `pnpm typecheck` passes on current `main` with this change (it is safe to merge before the upstream PR).

## Testing

- `pnpm typecheck` green on current generated types
- The only consumer (`buildNextTurnParamsContext`) assigns `request.models ?? []`, which is exactly this type
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-sdk/pull/821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->