### PR TITLE
feat: read OPENROUTER_BASE_URL as the default serverURL

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@
  * @generated-id: 320761608fb3
  */
 
+import { env } from "./env.js";
 import { HTTPClient } from "./http.js";
 import { Logger } from "./logger.js";
 import { RetryConfig } from "./retries.js";
@@ -43,7 +44,8 @@ export type SDKOptions = {
    */
   server?: keyof typeof ServerList | undefined;
   /**
-   * Allows overriding the default server URL used by the SDK
+   * Allows overriding the default server URL used by the SDK. When omitted, the
+   * `OPENROUTER_BASE_URL` environment variable is used, if set.
    */
   serverURL?: string | undefined;
   /**
@@ -64,8 +66,10 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
   const params: Params = {};
 
   if (!serverURL) {
-    const server = options.server ?? ServerProduction;
-    serverURL = ServerList[server] || "";
+    const server = options.server;
+    serverURL =
+      (server ? ServerList[server] : env().OPENROUTER_BASE_URL) ||
+      ServerList[ServerProduction];
   }
 
   const u = pathToFunc(serverURL)(params);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -25,6 +25,12 @@ export interface Env {
   OPENROUTER_APP_CATEGORIES?: string | undefined;
 
   OPENROUTER_DEBUG?: boolean | undefined;
+
+  /**
+   * Sets the default server URL used by the SDK. Must include the API version
+   * path, for example `https://openrouter.ai/api/v1`.
+   */
+  OPENROUTER_BASE_URL?: string | undefined;
 }
 
 export const envSchema: z.ZodType<Env, unknown> = z.object({
@@ -35,6 +41,8 @@ export const envSchema: z.ZodType<Env, unknown> = z.object({
   OPENROUTER_APP_CATEGORIES: z.string().optional(),
 
   OPENROUTER_DEBUG: z.coerce.boolean().optional(),
+
+  OPENROUTER_BASE_URL: z.string().url().optional(),
 });
 
 /**

--- a/tests/unit/server-url-env.test.ts
+++ b/tests/unit/server-url-env.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { serverURLFromOptions } from '../../src/lib/config.js';
+import { resetEnv } from '../../src/lib/env.js';
+
+const PRODUCTION_URL = 'https://openrouter.ai/api/v1';
+
+describe('serverURLFromOptions with OPENROUTER_BASE_URL', () => {
+  const original = process.env['OPENROUTER_BASE_URL'];
+
+  beforeEach(() => {
+    resetEnv();
+  });
+
+  afterEach(() => {
+    if (typeof original === 'undefined') {
+      delete process.env['OPENROUTER_BASE_URL'];
+    } else {
+      process.env['OPENROUTER_BASE_URL'] = original;
+    }
+    resetEnv();
+  });
+
+  it('falls back to the production URL when the env var is unset', () => {
+    delete process.env['OPENROUTER_BASE_URL'];
+
+    expect(serverURLFromOptions({})?.toString()).toBe(`${PRODUCTION_URL}`);
+  });
+
+  it('uses the env var when no serverURL is supplied', () => {
+    process.env['OPENROUTER_BASE_URL'] = 'https://gateway.example.com/api/v1';
+
+    expect(serverURLFromOptions({})?.toString()).toBe(
+      'https://gateway.example.com/api/v1',
+    );
+  });
+
+  it('prefers an explicit serverURL over the env var', () => {
+    process.env['OPENROUTER_BASE_URL'] = 'https://gateway.example.com/api/v1';
+
+    expect(
+      serverURLFromOptions({ serverURL: 'https://explicit.example.com/api/v1' })
+        ?.toString(),
+    ).toBe('https://explicit.example.com/api/v1');
+  });
+
+  it('prefers an explicit server name over the env var', () => {
+    process.env['OPENROUTER_BASE_URL'] = 'https://gateway.example.com/api/v1';
+
+    expect(serverURLFromOptions({ server: 'production' })?.toString()).toBe(
+      PRODUCTION_URL,
+    );
+  });
+
+  it('rejects an env var that is not a valid URL', () => {
+    process.env['OPENROUTER_BASE_URL'] = 'not-a-url';
+
+    expect(() => serverURLFromOptions({})).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Gateways and hosting platforms (Netlify Functions, for example) inject a base URL into the environment so AI SDKs work with zero config. The OpenAI, Anthropic, and Google SDKs all read one (`OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, `GOOGLE_GEMINI_BASE_URL`); we only read `OPENROUTER_API_KEY`, so users had to write `serverURL: process.env.OPENROUTER_BASE_URL` by hand. This adds `OPENROUTER_BASE_URL` to the env schema and uses it as the default in `serverURLFromOptions`.

Resolution order is now, highest first:

```ts
options.serverURL            // explicit URL wins
ServerList[options.server]   // explicit named server wins over the env var
env().OPENROUTER_BASE_URL    // new
ServerList["production"]     // https://openrouter.ai/api/v1
```

The env var is the **complete** base URL including the version path, matching our production default (`https://openrouter.ai/api/v1`); the SDK does not append `/api/v1` itself. It is validated by the existing Zod env schema as `z.string().url()`, so a malformed value throws at client construction rather than at request time.

Covered by `tests/unit/server-url-env.test.ts`: env fallback, explicit `serverURL` precedence, explicit `server` precedence, production fallback when unset, and rejection of an invalid value.

Both touched files are Speakeasy-generated but have persistent edits enabled (`.speakeasy/gen.yaml`), so these changes survive regeneration via 3-way merge.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/b64d9151111742fd88382d4fcdb13ede
Requested by: @seawatts
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-sdk/pull/832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->